### PR TITLE
perf(openfoam): improve openFOAM polyMesh parsing and bound memory

### DIFF
--- a/src/meshlane/openfoam/_openfoam.py
+++ b/src/meshlane/openfoam/_openfoam.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import logging
 import re
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 import numpy as np
 
@@ -28,8 +28,8 @@ def _detect_format(path: Path) -> tuple[str, int, int]:
     label_bytes  : 4 (label=32) or 8 (label=64)
     scalar_bytes : 4 (scalar=32) or 8 (scalar=64)
     """
-    fmt          = "ascii"
-    label_bytes  = 8
+    fmt = "ascii"
+    label_bytes = 8
     scalar_bytes = 8
 
     with open(path, "rb") as f:
@@ -49,7 +49,7 @@ def _detect_format(path: Path) -> tuple[str, int, int]:
                 ml = re.search(r"label=(\d+)", arch)
                 ms = re.search(r"scalar=(\d+)", arch)
                 if ml:
-                    label_bytes  = int(ml.group(1)) // 8
+                    label_bytes = int(ml.group(1)) // 8
                 if ms:
                     scalar_bytes = int(ms.group(1)) // 8
 
@@ -60,179 +60,187 @@ def _detect_format(path: Path) -> tuple[str, int, int]:
     return fmt, label_bytes, scalar_bytes
 
 
-def _find_n_and_data_start(
-    raw: bytes,
-    skip_paren: bool = False,
-) -> tuple[int, int]:
+class _RaggedArray:
     """
-    Iterates through `raw` line by line (ASCII) to find:
-        1. The end of the FoamFile header (line containing '}')
-        2. The number N (first purely numeric line after the header)
-        3. Optionally the line '(' and the empty line that may follow it
-           (if skip_paren=True)
-    Returns (N, offset_start_of_binary_data).
+    Rows of variable length stored in CSR (compressed sparse row) form.
+
+    A polyMesh has two ragged integer relations -- faces (node ids per face)
+    and cell topology (face ids per cell) -- both of which would cost several
+    gigabytes as a Python ``list[list[int]]`` on an industrial mesh (tens of
+    millions of rows). CSR stores them as two flat numpy arrays instead:
+
+    * ``conn`` -- every row's values concatenated back to back;
+    * ``off``  -- length ``n_rows + 1``, so row ``i`` is
+      ``conn[off[i]:off[i + 1]]``.
+
+    Indexing (``a[i]``) and ``len(a)`` behave like the list-of-lists they
+    replace, so consumers need no special-casing.
     """
-    pos         = 0
-    in_foam     = False
-    depth       = 0
-    header_done = False
-    n           = None
 
-    while pos < len(raw):
-        nl = raw.find(b"\n", pos)
-        if nl == -1:
-            nl = len(raw) - 1
+    __slots__ = ("conn", "off")
 
-        line = raw[pos:nl].decode("ascii", errors="replace").strip()
+    def __init__(self, conn: np.ndarray, off: np.ndarray):
+        self.conn = conn
+        self.off = off
 
-        # Phase 1: consume the header
-        if not header_done:
-            if "FoamFile" in line:
-                in_foam = True
-            if in_foam:
-                depth += line.count("{") - line.count("}")
-                if depth <= 0 and "}" in line:
-                    header_done = True
-            pos = nl + 1
-            continue
+    @classmethod
+    def from_lists(cls, rows: list) -> "_RaggedArray":
+        """Build from a Python list-of-lists (used for small ASCII inputs)."""
+        if len(rows) == 0:
+            return cls(np.empty(0, dtype=np.int64), np.zeros(1, dtype=np.int64))
+        sizes = np.fromiter((len(r) for r in rows), dtype=np.int64, count=len(rows))
+        off = np.empty(len(rows) + 1, dtype=np.int64)
+        off[0] = 0
+        np.cumsum(sizes, out=off[1:])
+        conn = np.fromiter(
+            (int(v) for r in rows for v in r), dtype=np.int64, count=int(off[-1])
+        )
+        return cls(conn, off)
 
-        # Phase 2: after the header
-        # Skip empty lines and comments
-        if not line or line.startswith("//") or line.startswith("/*"):
-            pos = nl + 1
-            continue
+    def __len__(self) -> int:
+        return len(self.off) - 1
 
-        # Find N
-        if n is None and line.isdigit():
-            n   = int(line)
-            pos = nl + 1
-            continue
+    def __getitem__(self, i: int) -> np.ndarray:
+        return self.conn[self.off[i] : self.off[i + 1]]
 
-        # After N
-        if n is not None:
-            if skip_paren and line == "(":
-                pos = nl + 1
-                # Skip optional empty line following "("
-                nl2  = raw.find(b"\n", pos)
-                if nl2 == -1:
-                    nl2 = len(raw) - 1
-                line2 = raw[pos:nl2].decode("ascii", errors="replace").strip()
-                if not line2:
-                    pos = nl2 + 1
-                return n, pos
-            if not skip_paren:
-                # Data starts at this position
-                return n, pos
+    def sizes(self) -> np.ndarray:
+        """Length of every row, as a numpy array."""
+        return np.diff(self.off)
 
-        pos = nl + 1
+    def to_lists(self) -> list:
+        """Materialise back to a Python list-of-lists (used by tests)."""
+        return [
+            self.conn[self.off[i] : self.off[i + 1]].tolist() for i in range(len(self))
+        ]
 
-    raise ValueError(
-        f"Could not find data block (n={n}, skip_paren={skip_paren})"
-    )
+
+def _data_start(raw: bytes) -> tuple[int, int]:
+    """
+    Return (N, offset just after the outer '(') for a binary OpenFOAM List.
+
+    Layout (verified against real polyMesh output)::
+
+        FoamFile { ... }
+        // * * * ...
+        N
+        (<binary data ...
+
+    For contiguous lists (vectorField, labelList) the binary data starts
+    immediately after '('. ``N`` is the last integer between the header's
+    closing '}' and that '('.
+    """
+    end = raw.find(b"}")  # end of the FoamFile header block
+    if end == -1:
+        raise ValueError("No FoamFile header found")
+    lp = raw.find(b"(", end)  # '(' opening the outer list
+    if lp == -1:
+        raise ValueError("No '(' opening the data list found")
+    nums = re.findall(rb"\d+", raw[end:lp])
+    if not nums:
+        raise ValueError("No element count found before '('")
+    return int(nums[-1]), lp + 1
 
 
 def _read_binary_points(path: Path, scalar_bytes: int = 8) -> np.ndarray:
-    """
-    Binary points structure:
-        <ASCII header>
-        N\\n
-        <N * 3 * scalar bytes binary>   (no parentheses)
-    """
+    """Binary vectorField:  N ( <N*3*scalar bytes binary> )."""
     raw = path.read_bytes()
-    n, data_start = _find_n_and_data_start(raw, skip_paren=False)
+    n, start = _data_start(raw)
 
-    dtype    = "<f4" if scalar_bytes == 4 else "<f8"
+    dtype = "<f4" if scalar_bytes == 4 else "<f8"
     expected = n * 3 * scalar_bytes
-    pts_raw  = raw[data_start: data_start + expected]
-
-    if len(pts_raw) != expected:
+    if len(raw) - start < expected:
         raise ValueError(
-            f"points: expected {expected} bytes, got {len(pts_raw)} "
-            f"(n={n}, data_start={data_start}, file_size={len(raw)})"
+            f"points: expected {expected} bytes, got {len(raw) - start} "
+            f"(n={n}, start={start}, file_size={len(raw)})"
         )
-
-    return np.frombuffer(pts_raw, dtype=dtype).reshape(n, 3).astype(float).copy()
+    return (
+        np.frombuffer(raw, dtype=dtype, count=n * 3, offset=start)
+        .reshape(n, 3)
+        .astype(float)
+    )
 
 
 def _read_binary_labels(path: Path, label_bytes: int = 4) -> np.ndarray:
-    """
-    Binary owner/neighbour structure:
-        <ASCII header>
-        N\\n
-        <N * label bytes binary>   (no parentheses)
-    """
+    """Binary labelList (owner/neighbour):  N ( <N*label bytes binary> )."""
     raw = path.read_bytes()
-    n, data_start = _find_n_and_data_start(raw, skip_paren=False)
+    n, start = _data_start(raw)
 
-    dtype    = "<i4" if label_bytes == 4 else "<i8"
+    dtype = "<i4" if label_bytes == 4 else "<i8"
     expected = n * label_bytes
-    arr_raw  = raw[data_start: data_start + expected]
-
-    if len(arr_raw) != expected:
+    if len(raw) - start < expected:
         raise ValueError(
-            f"labels: expected {expected} bytes, got {len(arr_raw)} "
-            f"(n={n}, data_start={data_start})"
+            f"labels: expected {expected} bytes, got {len(raw) - start} "
+            f"(n={n}, start={start})"
+        )
+    return np.frombuffer(raw, dtype=dtype, count=n, offset=start).astype(np.int64)
+
+
+def _read_binary_faces(path: Path, label_bytes: int = 4) -> _RaggedArray:
+    """
+    Binary OpenFOAM faceList -> CSR ``_RaggedArray``.
+
+    A ``List<face>`` is non-contiguous, so each face is serialised as a
+    ``labelList``::
+
+        N
+        (
+        <M> ( <M*label bytes binary> )
+        <M> ( <M*label bytes binary> )
+        ...
         )
 
-    return np.frombuffer(arr_raw, dtype=dtype).astype(np.int64).copy()
+    Two passes, both memory bounded:
 
-
-def _read_binary_faces(path: Path, label_bytes: int = 4) -> list[list[int]]:
+    1. Sequential scan recording, per face, its node count and the byte offset
+       of its binary blob. ``raw.find(b"(")`` only ever scans the short ASCII
+       gap between one face's ')' and the next face's '(' -- never the binary
+       blob -- so binary bytes that happen to equal '(' are never misread.
+    2. Vectorised gather of all blob bytes via a byte mask (the blob ranges are
+       disjoint, so a +1/-1 diff + cumsum marks them), then a single
+       ``view`` to the label dtype.
     """
-    Binary OpenFOAM faces structure:
-        <ASCII header>
-        N\\n
-        (\\n
-        \\n                           <- optional empty line
-        <n_pts_face_0>\\n             <- ASCII
-        [n_pts * label bytes binary] <- points of face 0
-        \\n                           <- separator
-        <n_pts_face_1>\\n
-        [n_pts * label bytes binary]
-        ...
-        )\\n
-    """
-    raw   = path.read_bytes()
-    dtype = "<i4" if label_bytes == 4 else "<i8"
+    raw = path.read_bytes()
+    nfaces, pos = _data_start(raw)
 
-    n, pos = _find_n_and_data_start(raw, skip_paren=True)
+    counts = np.empty(nfaces, dtype=np.int32)
+    offsets = np.empty(nfaces, dtype=np.int64)  # byte offset of each blob
+    find = raw.find
+    p = pos
+    for i in range(nfaces):
+        lp = find(b"(", p)  # scans only the ASCII gap
+        if lp == -1:
+            raise ValueError(f"faces: missing '(' for face {i}")
+        counts[i] = int(raw[p:lp])  # ASCII count, tolerates ws
+        blob = lp + 1
+        offsets[i] = blob
+        p = blob + int(counts[i]) * label_bytes + 1  # skip blob and ')'
 
-    faces = []
-    for _ in range(n):
-        # Skip empty lines / separators
-        while pos < len(raw):
-            nl   = raw.find(b"\n", pos)
-            if nl == -1:
-                nl = len(raw) - 1
-            line = raw[pos:nl].decode("ascii", errors="replace").strip()
-            if line and line.isdigit():
-                npts = int(line)
-                pos  = nl + 1
-                break
-            if line == ")":
-                return faces
-            pos = nl + 1
+    off = np.empty(nfaces + 1, dtype=np.int64)
+    off[0] = 0
+    np.cumsum(counts, out=off[1:])
 
-        # Read npts binary labels
-        nbytes = npts * label_bytes
-        pts    = np.frombuffer(raw[pos: pos + nbytes], dtype=dtype).tolist()
-        faces.append([int(p) for p in pts])
-        pos   += nbytes
+    nbytes = counts.astype(np.int64) * label_bytes
+    diff = np.zeros(len(raw) + 1, dtype=np.int8)
+    np.add.at(diff, offsets, 1)
+    np.add.at(diff, offsets + nbytes, -1)
+    mask = np.cumsum(diff[:-1], dtype=np.int8).astype(bool)
 
-    return faces
+    buf = np.frombuffer(raw, dtype=np.uint8)
+    conn = buf[mask].view("<i4" if label_bytes == 4 else "<i8").astype(np.int64)
+    return _RaggedArray(conn, off)
 
 
 def _strip_comments(text: str) -> str:
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
-    text = re.sub(r"//.*",      "",  text)
+    text = re.sub(r"//.*", "", text)
     return text
 
 
 def _skip_header(lines: list[str]) -> list[str]:
     """Remove the FoamFile { ... } block."""
     in_header = False
-    depth     = 0
-    result    = []
+    depth = 0
+    result = []
     for line in lines:
         s = line.strip()
         if "FoamFile" in s:
@@ -253,10 +261,10 @@ def _read_foam_lines(path: Path) -> list[str]:
 
 
 def _parse_points_ascii(lines: list[str]) -> np.ndarray:
-    coords   = []
+    coords = []
     in_block = False
-    n        = None
-    num      = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
+    n = None
+    num = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
     for line in lines:
         s = line.strip()
         if not s:
@@ -280,10 +288,10 @@ def _parse_points_ascii(lines: list[str]) -> np.ndarray:
 
 
 def _parse_faces_ascii(lines: list[str]) -> list[list[int]]:
-    faces    = []
+    faces = []
     in_block = False
-    n        = None
-    face_re  = re.compile(r"(\d+)\s*\(([^)]+)\)")
+    n = None
+    face_re = re.compile(r"(\d+)\s*\(([^)]+)\)")
     for line in lines:
         s = line.strip()
         if not s:
@@ -307,9 +315,9 @@ def _parse_faces_ascii(lines: list[str]) -> list[list[int]]:
 
 
 def _parse_int_list_ascii(lines: list[str]) -> np.ndarray:
-    tokens   = []
+    tokens = []
     in_block = False
-    n        = None
+    n = None
     for line in lines:
         s = line.strip()
         if not s:
@@ -330,7 +338,7 @@ def _parse_int_list_ascii(lines: list[str]) -> np.ndarray:
 def _parse_boundary(lines: list[str]) -> dict:
     """Returns {patch_name: {type, nFaces, startFace}}."""
     patches = {}
-    flat    = "\n".join(lines)
+    flat = "\n".join(lines)
     pattern = re.compile(r"(\w+)\s*\{([^}]*)\}", re.DOTALL)
     for match in pattern.finditer(flat):
         name = match.group(1)
@@ -340,12 +348,12 @@ def _parse_boundary(lines: list[str]) -> dict:
             m = re.search(rf"{key}\s+([^\s;]+)\s*;", body)
             return m.group(1) if m else None
 
-        n_faces    = _get("nFaces")
+        n_faces = _get("nFaces")
         start_face = _get("startFace")
         if n_faces is not None and start_face is not None:
             patches[name] = {
-                "type":      _get("type"),
-                "nFaces":    int(n_faces),
+                "type": _get("type"),
+                "nFaces": int(n_faces),
                 "startFace": int(start_face),
             }
     return patches
@@ -359,14 +367,12 @@ def _read_points(path: Path) -> np.ndarray:
     return _parse_points_ascii(_read_foam_lines(path))
 
 
-def _read_faces(path: Path) -> list[list[int]]:
+def _read_faces(path: Path) -> _RaggedArray:
     fmt, label_bytes, scalar_bytes = _detect_format(path)
     if fmt == "binary":
-        logger.info(
-            "Reading binary faces from %s (label=%d B)", path.name, label_bytes
-        )
+        logger.info("Reading binary faces from %s (label=%d B)", path.name, label_bytes)
         return _read_binary_faces(path, label_bytes)
-    return _parse_faces_ascii(_read_foam_lines(path))
+    return _RaggedArray.from_lists(_parse_faces_ascii(_read_foam_lines(path)))
 
 
 def _read_int_list(path: Path) -> np.ndarray:
@@ -382,6 +388,7 @@ def _read_int_list(path: Path) -> np.ndarray:
 # ---------------------------------------------------------------------------
 # Geometry helpers
 # ---------------------------------------------------------------------------
+
 
 def _triple(a, b, c) -> float:
     """Scalar triple product a · (b × c)."""
@@ -400,21 +407,30 @@ def _node_adjacency(faces) -> dict:
     return adj
 
 
-def _build_cell_to_faces(n_cells, owner, neighbour):
+def _cell_faces_csr(n_cells, owner, neighbour) -> _RaggedArray:
     """
-    Returns cell_faces[i] = list of face ids touching cell i.
+    Vectorised cell -> faces topology as a CSR :class:`_RaggedArray`.
 
-    Handles two conventions:
-      - neighbour of length nInternalFaces (standard OpenFOAM)
-      - neighbour of length nFaces with -1 for boundary faces
+    Row ``c`` holds the ids of every face touching cell ``c``. Handles both
+    neighbour conventions: length nInternalFaces (standard OpenFOAM), or
+    length nFaces with -1 on boundary faces.
     """
-    cell_faces = [[] for _ in range(n_cells)]
-    n_nb = len(neighbour)
-    for fid in range(len(owner)):
-        cell_faces[int(owner[fid])].append(fid)
-        if fid < n_nb and neighbour[fid] >= 0:
-            cell_faces[int(neighbour[fid])].append(fid)
-    return cell_faces
+    if n_cells == 0:
+        return _RaggedArray(np.empty(0, dtype=np.int64), np.zeros(1, dtype=np.int64))
+
+    internal = neighbour >= 0
+    cell_of = np.concatenate([owner, neighbour[internal]])
+    face_of = np.concatenate(
+        [np.arange(len(owner)), np.arange(len(neighbour))[internal]]
+    )
+    order = np.argsort(cell_of, kind="stable")  # group faces by cell id
+    cf_flat = face_of[order]
+
+    fpc = np.bincount(cell_of, minlength=n_cells)
+    cf_off = np.empty(n_cells + 1, dtype=np.int64)
+    cf_off[0] = 0
+    np.cumsum(fpc, out=cf_off[1:])
+    return _RaggedArray(cf_flat, cf_off)
 
 
 def _outward_faces(cell_faces, faces, owner, cell_id):
@@ -427,9 +443,7 @@ def _outward_faces(cell_faces, faces, owner, cell_id):
     oriented = []
     for fid in cell_faces:
         f = faces[fid]
-        oriented.append(
-            list(f) if int(owner[fid]) == cell_id else list(reversed(f))
-        )
+        oriented.append(list(f) if int(owner[fid]) == cell_id else list(reversed(f)))
     return oriented
 
 
@@ -438,9 +452,9 @@ def _match_top(bottom, oriented):
     For each base node, find its unique vertical neighbour.
     Returns the ordered top ring, or None if the topology is ambiguous.
     """
-    adj  = _node_adjacency(oriented)
+    adj = _node_adjacency(oriented)
     base = set(bottom)
-    top  = []
+    top = []
     for b in bottom:
         cand = [x for x in adj[b] if x not in base]
         if len(cand) != 1:
@@ -453,8 +467,8 @@ def _build_tetra(oriented, P):
     """Build a tetrahedron connectivity with positive volume orientation."""
     base = oriented[0]
     apex = (set().union(*oriented) - set(base)).pop()
-    n    = [base[0], base[1], base[2], apex]
-    p    = [P[i] for i in n]
+    n = [base[0], base[1], base[2], apex]
+    p = [P[i] for i in n]
     if _triple(p[1] - p[0], p[2] - p[0], p[3] - p[0]) < 0:
         n = [base[0], base[2], base[1], apex]
     return n
@@ -464,8 +478,8 @@ def _build_pyramid(oriented, P):
     """Build a pyramid connectivity with positive volume orientation."""
     quad = next(f for f in oriented if len(f) == 4)
     apex = (set().union(*oriented) - set(quad)).pop()
-    n    = list(quad) + [apex]
-    p    = [P[i] for i in n]
+    n = list(quad) + [apex]
+    p = [P[i] for i in n]
     if _triple(p[1] - p[0], p[3] - p[0], p[4] - p[0]) < 0:
         n = [quad[0], quad[3], quad[2], quad[1], apex]
     return n
@@ -474,7 +488,7 @@ def _build_pyramid(oriented, P):
 def _build_wedge(oriented, P):
     """Build a wedge connectivity with positive volume orientation."""
     bottom = next(f for f in oriented if len(f) == 3)
-    top    = _match_top(bottom, oriented)
+    top = _match_top(bottom, oriented)
     if top is None:
         return None
     n = list(bottom) + top
@@ -487,21 +501,20 @@ def _build_wedge(oriented, P):
 def _build_hexahedron(oriented, P):
     """Build a hexahedron connectivity with positive volume orientation."""
     bottom = next(f for f in oriented if len(f) == 4)
-    top    = _match_top(bottom, oriented)
+    top = _match_top(bottom, oriented)
     if top is None:
         return None
     n = list(bottom) + top
     p = [P[i] for i in n]
     if _triple(p[1] - p[0], p[3] - p[0], p[4] - p[0]) < 0:
-        n = [bottom[0], bottom[3], bottom[2], bottom[1],
-             top[0],    top[3],    top[2],    top[1]]
+        n = [bottom[0], bottom[3], bottom[2], bottom[1], top[0], top[3], top[2], top[1]]
     return n
 
 
 def _build_boundary_polygons(poly_faces, poly_tags):
     """Split boundary polygons by vertex count -> polygonN CellBlocks."""
-    by_n   = defaultdict(list)
-    tag_n  = defaultdict(list)
+    by_n = defaultdict(list)
+    tag_n = defaultdict(list)
     for f, t in zip(poly_faces, poly_tags):
         by_n[len(f)].append(list(f))
         tag_n[len(f)].append(t)
@@ -536,14 +549,14 @@ def _reconstruct_cell(oriented, P):
       - for 'polyhedron'   : connectivity is the list of outward-oriented faces
     """
     n_faces = len(oriented)
-    n_pts   = len(set().union(*oriented))
+    n_pts = len(set().union(*oriented))
 
     if n_faces == 4 and n_pts == 4:
-        return "tetra",      _build_tetra(oriented, P)
+        return "tetra", _build_tetra(oriented, P)
     if n_faces == 5 and n_pts == 5:
-        return "pyramid",    _build_pyramid(oriented, P)
+        return "pyramid", _build_pyramid(oriented, P)
     if n_faces == 5 and n_pts == 6:
-        return "wedge",      _build_wedge(oriented, P)
+        return "wedge", _build_wedge(oriented, P)
     if n_faces == 6 and n_pts == 8:
         return "hexahedron", _build_hexahedron(oriented, P)
 
@@ -552,15 +565,26 @@ def _reconstruct_cell(oriented, P):
 
 
 def _build_volume_cells(n_cells, faces, owner, neighbour, P):
-    """Build volume CellBlocks from raw polyMesh data."""
-    cell_faces_map = _build_cell_to_faces(n_cells, owner, neighbour)
+    """
+    Build volume CellBlocks from raw polyMesh data.
 
-    buckets:    dict[str, list] = {}
-    poly_cells: list            = []
+    Uses a vectorised CSR cell -> faces topology and reads each face from the
+    CSR ``_RaggedArray`` (or a plain list of faces), so peak memory stays bounded
+    even for meshes with millions of cells. The per-cell classification reuses
+    the orientation-aware reconstruction helpers unchanged.
+    """
+    cell_faces = _cell_faces_csr(n_cells, owner, neighbour)
+    owner = np.asarray(owner)
+
+    buckets: dict[str, list] = {}
+    poly_cells: list = []
     n_skipped = 0
 
-    for cell_id, cf in enumerate(cell_faces_map):
-        oriented    = _outward_faces(cf, faces, owner, cell_id)
+    for cell_id in range(n_cells):
+        oriented = [
+            list(faces[f]) if int(owner[f]) == cell_id else list(faces[f])[::-1]
+            for f in cell_faces[cell_id]
+        ]
         mtype, conn = _reconstruct_cell(oriented, P)
 
         if mtype == "polyhedron":
@@ -575,10 +599,7 @@ def _build_volume_cells(n_cells, faces, owner, neighbour, P):
     if poly_cells:
         logger.info("%d general polyhedron cell(s) found.", len(poly_cells))
 
-    cells = [
-        CellBlock(t, np.array(c, dtype=int))
-        for t, c in buckets.items()
-    ]
+    cells = [CellBlock(t, np.array(c, dtype=int)) for t, c in buckets.items()]
 
     if poly_cells:
         cells.extend(_build_polyhedra(poly_cells))
@@ -593,14 +614,14 @@ def _build_boundary_cells(boundary, faces):
     Triangles and quads  -> regular 2-D CellBlocks.
     Polygons (n > 4)     -> grouped by vertex count via _build_boundary_polygons.
     """
-    by_size:      dict[int, list] = {3: [], 4: []}
+    by_size: dict[int, list] = {3: [], 4: []}
     tags_by_size: dict[int, list] = {3: [], 4: []}
-    poly_faces:   list            = []
-    poly_tags:    list            = []
-    patch_tags:   dict            = {}
+    poly_faces: list = []
+    poly_tags: list = []
+    patch_tags: dict = {}
 
     for patch_id, (name, info) in enumerate(boundary.items()):
-        fam = -(patch_id + 1)   # MED family id (negative)
+        fam = -(patch_id + 1)  # MED family id (negative)
         patch_tags[fam] = [name]
         for fid in range(info["startFace"], info["startFace"] + info["nFaces"]):
             if fid >= len(faces):
@@ -617,7 +638,7 @@ def _build_boundary_cells(boundary, faces):
                 poly_tags.append(fam)
 
     cells: list = []
-    tags:  list = []
+    tags: list = []
 
     for size, mtype in ((3, "triangle"), (4, "quad")):
         if by_size[size]:
@@ -625,9 +646,7 @@ def _build_boundary_cells(boundary, faces):
             tags.append(np.array(tags_by_size[size], dtype=int))
 
     if poly_faces:
-        logger.info(
-            "%d boundary polygon(s) with n>4 nodes found.", len(poly_faces)
-        )
+        logger.info("%d boundary polygon(s) with n>4 nodes found.", len(poly_faces))
         poly_cells, poly_tag_arrays = _build_boundary_polygons(poly_faces, poly_tags)
         cells.extend(poly_cells)
         tags.extend(poly_tag_arrays)
@@ -638,6 +657,7 @@ def _build_boundary_cells(boundary, faces):
 # ---------------------------------------------------------------------------
 # polyMesh path resolution
 # ---------------------------------------------------------------------------
+
 
 def _resolve_polymesh(path: Path) -> Path:
     """Locate the polyMesh directory from a .foam file, case dir, or polyMesh dir."""
@@ -660,14 +680,15 @@ def _resolve_polymesh(path: Path) -> Path:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def read(filename) -> Mesh:
     """Read an OpenFOAM polyMesh case and return a :class:`meshlane.Mesh`."""
     poly = _resolve_polymesh(Path(filename))
     logger.info("Reading polyMesh from %s", poly)
 
-    points    = _read_points(poly / "points")
-    faces     = _read_faces(poly / "faces")
-    owner     = _read_int_list(poly / "owner")
+    points = _read_points(poly / "points")
+    faces = _read_faces(poly / "faces")
+    owner = _read_int_list(poly / "owner")
     neighbour = (
         _read_int_list(poly / "neighbour")
         if (poly / "neighbour").exists()
@@ -686,13 +707,14 @@ def read(filename) -> Mesh:
     )
     logger.info(
         "%d points, %d faces, %d cells, %d patches",
-        len(points), len(faces), n_cells, len(boundary),
+        len(points),
+        len(faces),
+        n_cells,
+        len(boundary),
     )
 
     vol_cells = _build_volume_cells(n_cells, faces, owner, neighbour, points)
-    patch_cells, patch_tags_data, patch_tags = _build_boundary_cells(
-        boundary, faces
-    )
+    patch_cells, patch_tags_data, patch_tags = _build_boundary_cells(boundary, faces)
 
     cells = vol_cells + patch_cells
 
@@ -704,7 +726,7 @@ def read(filename) -> Mesh:
         cells=cells,
         cell_data={"cell_tags": cell_data_tags} if cell_data_tags else {},
     )
-    mesh.cell_tags  = patch_tags
+    mesh.cell_tags = patch_tags
     mesh.point_tags = {}
     return mesh
 

--- a/tests/test_openfoam.py
+++ b/tests/test_openfoam.py
@@ -10,36 +10,35 @@ import numpy as np
 import pytest
 
 from meshlane.openfoam._openfoam import (
+    _build_boundary_cells,
+    _build_boundary_polygons,
+    _build_hexahedron,
+    _build_polyhedra,
+    _build_pyramid,
+    _build_tetra,
+    _build_volume_cells,
+    _build_wedge,
+    _cell_faces_csr,
+    _data_start,
     _detect_format,
-    _find_n_and_data_start,
-    _read_binary_points,
-    _read_binary_labels,
-    _read_binary_faces,
-    _strip_comments,
-    _skip_header,
-    _read_foam_lines,
-    _parse_points_ascii,
+    _match_top,
+    _node_adjacency,
+    _outward_faces,
+    _parse_boundary,
     _parse_faces_ascii,
     _parse_int_list_ascii,
-    _parse_boundary,
-    _triple,
-    _node_adjacency,
-    _build_cell_to_faces,
-    _outward_faces,
-    _match_top,
-    _build_tetra,
-    _build_pyramid,
-    _build_wedge,
-    _build_hexahedron,
-    _build_boundary_polygons,
-    _build_polyhedra,
-    _reconstruct_cell,
-    _build_volume_cells,
-    _build_boundary_cells,
-    _resolve_polymesh,
-    _read_points,
+    _parse_points_ascii,
+    _read_binary_faces,
+    _read_binary_labels,
+    _read_binary_points,
     _read_faces,
+    _read_foam_lines,
     _read_int_list,
+    _read_points,
+    _reconstruct_cell,
+    _resolve_polymesh,
+    _strip_comments,
+    _triple,
     read,
 )
 
@@ -66,6 +65,7 @@ BINARY_HEADER = """FoamFile
 }}
 """
 
+
 def _write_ascii_points(path: Path, points: np.ndarray) -> None:
     lines = [ASCII_HEADER.format(cls="vectorField", obj="points")]
     lines.append(f"{len(points)}")
@@ -86,9 +86,7 @@ def _write_ascii_faces(path: Path, faces: list[list[int]]) -> None:
     path.write_text("\n".join(lines))
 
 
-def _write_ascii_labels(
-    path: Path, labels: list[int], obj: str = "owner"
-) -> None:
+def _write_ascii_labels(path: Path, labels: list[int], obj: str = "owner") -> None:
     lines = [ASCII_HEADER.format(cls="labelList", obj=obj)]
     lines.append(f"{len(labels)}")
     lines.append("(")
@@ -116,10 +114,19 @@ def _write_ascii_boundary(path: Path, patches: dict) -> None:
 @pytest.fixture
 def hex_cube_data():
     """A single hexahedral cell bounded by 6 quad faces."""
-    points = np.array([
-        [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-        [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
-    ], dtype=float)
+    points = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
 
     faces = [
         [0, 3, 2, 1],  # bottom  (z=0)
@@ -129,12 +136,12 @@ def hex_cube_data():
         [1, 2, 6, 5],  # right   (x=1)
         [0, 4, 7, 3],  # left    (x=0)
     ]
-    owner:     list[int] = [0] * 6
+    owner: list[int] = [0] * 6
     neighbour: list[int] = []
     boundary = {
         "bottom": {"type": "wall", "nFaces": 1, "startFace": 0},
-        "top":    {"type": "wall", "nFaces": 1, "startFace": 1},
-        "sides":  {"type": "wall", "nFaces": 4, "startFace": 2},
+        "top": {"type": "wall", "nFaces": 1, "startFace": 1},
+        "sides": {"type": "wall", "nFaces": 4, "startFace": 2},
     }
     return points, faces, owner, neighbour, boundary
 
@@ -174,15 +181,13 @@ class TestStripComments:
         assert _strip_comments("") == ""
 
 
-
 class TestReadFoamLines:
     """Tests for the _read_foam_lines dispatcher."""
 
     def test_strips_comments_and_header(self, tmp_path):
         path = tmp_path / "f"
         path.write_text(
-            ASCII_HEADER.format(cls="x", obj="y")
-            + "\n// comment\n3\n(\na\nb\nc\n)\n"
+            ASCII_HEADER.format(cls="x", obj="y") + "\n// comment\n3\n(\na\nb\nc\n)\n"
         )
         lines = _read_foam_lines(path)
         # Header and comment must be gone; data lines must survive
@@ -201,7 +206,12 @@ class TestReadFoamLines:
 class TestParsePointsAscii:
     def test_basic(self):
         lines = [
-            "3", "(", "(0 0 0)", "(1.0 2.0 3.0)", "(-1 -2 -3.5e-1)", ")",
+            "3",
+            "(",
+            "(0 0 0)",
+            "(1.0 2.0 3.0)",
+            "(-1 -2 -3.5e-1)",
+            ")",
         ]
         pts = _parse_points_ascii(lines)
         assert pts.shape == (3, 3)
@@ -271,12 +281,14 @@ class TestParseIntListAscii:
 class TestParseBoundary:
     def test_basic(self):
         lines = [
-            "inlet",  "{",
+            "inlet",
+            "{",
             "    type        patch;",
             "    nFaces      10;",
             "    startFace   100;",
             "}",
-            "outlet", "{",
+            "outlet",
+            "{",
             "    type        patch;",
             "    nFaces      5;",
             "    startFace   110;",
@@ -295,7 +307,8 @@ class TestParseBoundary:
 
     def test_wall_type(self):
         lines = [
-            "wall1", "{",
+            "wall1",
+            "{",
             "    type wall;",
             "    nFaces 4;",
             "    startFace 20;",
@@ -343,51 +356,52 @@ class TestNodeAdjacency:
         assert 3 in adj[2]
 
 
-class TestBuildCellToFaces:
+class TestCellFacesCsr:
     def test_internal_and_boundary(self):
-        owner     = np.array([0, 0, 1])
-        neighbour = np.array([1])   # only the first face is internal
-        cf        = _build_cell_to_faces(2, owner, neighbour)
-        assert 0 in cf[0] and 1 in cf[0]
-        assert 0 in cf[1] and 2 in cf[1]
+        owner = np.array([0, 0, 1])
+        neighbour = np.array([1])  # only the first face is internal
+        cf = _cell_faces_csr(2, owner, neighbour)
+        assert set(cf[0].tolist()) == {0, 1}
+        assert set(cf[1].tolist()) == {0, 2}
 
     def test_with_negative_neighbour(self):
-        owner     = np.array([0, 0, 1])
+        # Face order within a cell is not meaningful; compare as sets.
+        owner = np.array([0, 0, 1])
         neighbour = np.array([1, -1, -1])
-        cf        = _build_cell_to_faces(2, owner, neighbour)
-        assert cf[0] == [0, 1]
-        assert cf[1] == [0, 2]
+        cf = _cell_faces_csr(2, owner, neighbour)
+        assert set(cf[0].tolist()) == {0, 1}
+        assert set(cf[1].tolist()) == {0, 2}
 
     def test_all_boundary(self):
-        owner     = np.array([0, 0, 0])
+        owner = np.array([0, 0, 0])
         neighbour = np.array([], dtype=int)
-        cf        = _build_cell_to_faces(1, owner, neighbour)
-        assert cf[0] == [0, 1, 2]
+        cf = _cell_faces_csr(1, owner, neighbour)
+        assert set(cf[0].tolist()) == {0, 1, 2}
 
     def test_two_cells_no_shared_face(self):
-        owner     = np.array([0, 0, 1, 1])
+        owner = np.array([0, 0, 1, 1])
         neighbour = np.array([], dtype=int)
-        cf        = _build_cell_to_faces(2, owner, neighbour)
-        assert cf[0] == [0, 1]
-        assert cf[1] == [2, 3]
+        cf = _cell_faces_csr(2, owner, neighbour)
+        assert set(cf[0].tolist()) == {0, 1}
+        assert set(cf[1].tolist()) == {2, 3}
 
 
 class TestOutwardFaces:
     def test_owner_unchanged(self):
-        faces  = [[0, 1, 2], [3, 4, 5]]
-        owner  = np.array([0, 0])
+        faces = [[0, 1, 2], [3, 4, 5]]
+        owner = np.array([0, 0])
         result = _outward_faces([0, 1], faces, owner, cell_id=0)
         assert result == [[0, 1, 2], [3, 4, 5]]
 
     def test_neighbour_reversed(self):
-        faces  = [[0, 1, 2]]
-        owner  = np.array([1])     # cell 0 is the neighbour
+        faces = [[0, 1, 2]]
+        owner = np.array([1])  # cell 0 is the neighbour
         result = _outward_faces([0], faces, owner, cell_id=0)
         assert result == [[2, 1, 0]]
 
     def test_mixed_owner_and_neighbour(self):
-        faces  = [[0, 1, 2], [3, 4, 5]]
-        owner  = np.array([0, 1])  # face 0 owned by cell 0, face 1 owned by cell 1
+        faces = [[0, 1, 2], [3, 4, 5]]
+        owner = np.array([0, 1])  # face 0 owned by cell 0, face 1 owned by cell 1
         result = _outward_faces([0, 1], faces, owner, cell_id=0)
         # face 0 : owner == 0 → unchanged
         assert result[0] == [0, 1, 2]
@@ -414,11 +428,11 @@ class TestMatchTop:
 
     def test_wedge_match(self):
         oriented = [
-            [0, 1, 2],          # bottom triangle
-            [3, 4, 5],          # top triangle
-            [0, 1, 4, 3],       # lateral quad
-            [1, 2, 5, 4],       # lateral quad
-            [2, 0, 3, 5],       # lateral quad
+            [0, 1, 2],  # bottom triangle
+            [3, 4, 5],  # top triangle
+            [0, 1, 4, 3],  # lateral quad
+            [1, 2, 5, 4],  # lateral quad
+            [2, 0, 3, 5],  # lateral quad
         ]
         top = _match_top([0, 1, 2], oriented)
         assert set(top) == {3, 4, 5}
@@ -426,9 +440,7 @@ class TestMatchTop:
 
 class TestBuildTetra:
     def test_basic(self):
-        P = np.array(
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float
-        )
+        P = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         oriented = [
             [0, 2, 1],
             [0, 1, 3],
@@ -443,9 +455,7 @@ class TestBuildTetra:
 
     def test_positive_volume(self):
         """Orientation must always yield positive triple product."""
-        P = np.array(
-            [[0, 0, 0], [2, 0, 0], [0, 2, 0], [0, 0, 2]], dtype=float
-        )
+        P = np.array([[0, 0, 0], [2, 0, 0], [0, 2, 0], [0, 0, 2]], dtype=float)
         oriented = [[0, 1, 2], [0, 3, 1], [1, 3, 2], [0, 2, 3]]
         conn = _build_tetra(oriented, P)
         p = [P[i] for i in conn]
@@ -454,12 +464,18 @@ class TestBuildTetra:
 
 class TestBuildPyramid:
     def test_basic(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-            [0.5, 0.5, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0.5, 0.5, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
-            [0, 3, 2, 1],   # square base (outward = -z)
+            [0, 3, 2, 1],  # square base (outward = -z)
             [0, 1, 4],
             [1, 2, 4],
             [2, 3, 4],
@@ -470,10 +486,16 @@ class TestBuildPyramid:
         assert set(conn) == {0, 1, 2, 3, 4}
 
     def test_apex_is_last(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-            [0.5, 0.5, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0.5, 0.5, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
             [0, 3, 2, 1],
             [0, 1, 4],
@@ -488,13 +510,20 @@ class TestBuildPyramid:
 
 class TestBuildWedge:
     def test_basic(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [0.5, 1, 0],
-            [0, 0, 1], [1, 0, 1], [0.5, 1, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0.5, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0.5, 1, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
-            [0, 2, 1],          # bottom triangle
-            [3, 4, 5],          # top triangle
+            [0, 2, 1],  # bottom triangle
+            [3, 4, 5],  # top triangle
             [0, 1, 4, 3],
             [1, 2, 5, 4],
             [2, 0, 3, 5],
@@ -505,10 +534,17 @@ class TestBuildWedge:
         assert set(conn) == {0, 1, 2, 3, 4, 5}
 
     def test_positive_volume(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [0.5, 1, 0],
-            [0, 0, 1], [1, 0, 1], [0.5, 1, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0.5, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0.5, 1, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
             [0, 2, 1],
             [3, 4, 5],
@@ -533,14 +569,14 @@ class TestBuildHexahedron:
     def test_positive_volume(self, hex_cube_data):
         points, faces, *_ = hex_cube_data
         conn = _build_hexahedron(faces, points)
-        p    = [points[i] for i in conn]
+        p = [points[i] for i in conn]
         assert _triple(p[1] - p[0], p[3] - p[0], p[4] - p[0]) >= 0
 
     def test_ambiguous_topology_returns_none(self):
         """Degenerate face list that cannot yield a valid top ring."""
-        P         = np.zeros((8, 3))
-        ambiguous = [[0, 1, 2, 3]] * 6   # every face is identical
-        result    = _build_hexahedron(ambiguous, P)
+        P = np.zeros((8, 3))
+        ambiguous = [[0, 1, 2, 3]] * 6  # every face is identical
+        result = _build_hexahedron(ambiguous, P)
         assert result is None
 
 
@@ -553,35 +589,52 @@ class TestReconstructCell:
         assert set(conn) == set(range(8))
 
     def test_tetra(self):
-        P = np.array(
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float
-        )
+        P = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
         oriented = [[0, 2, 1], [0, 1, 3], [1, 2, 3], [0, 3, 2]]
         mtype, conn = _reconstruct_cell(oriented, P)
         assert mtype == "tetra"
         assert len(conn) == 4
 
     def test_wedge(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [0.5, 1, 0],
-            [0, 0, 1], [1, 0, 1], [0.5, 1, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0.5, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0.5, 1, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
-            [0, 2, 1], [3, 4, 5],
-            [0, 1, 4, 3], [1, 2, 5, 4], [2, 0, 3, 5],
+            [0, 2, 1],
+            [3, 4, 5],
+            [0, 1, 4, 3],
+            [1, 2, 5, 4],
+            [2, 0, 3, 5],
         ]
         mtype, conn = _reconstruct_cell(oriented, P)
         assert mtype == "wedge"
         assert len(conn) == 6
 
     def test_pyramid(self):
-        P = np.array([
-            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-            [0.5, 0.5, 1],
-        ], dtype=float)
+        P = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0.5, 0.5, 1],
+            ],
+            dtype=float,
+        )
         oriented = [
             [0, 3, 2, 1],
-            [0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4],
+            [0, 1, 4],
+            [1, 2, 4],
+            [2, 3, 4],
+            [3, 0, 4],
         ]
         mtype, conn = _reconstruct_cell(oriented, P)
         assert mtype == "pyramid"
@@ -589,15 +642,15 @@ class TestReconstructCell:
 
     def test_polyhedron_general(self):
         oriented = [[0, 1, 2]] * 7
-        P        = np.zeros((3, 3))
+        P = np.zeros((3, 3))
         mtype, conn = _reconstruct_cell(oriented, P)
         assert mtype == "polyhedron"
 
 
 class TestBuildBoundaryPolygons:
     def test_groups_by_size(self):
-        faces    = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5]]
-        tags     = [-1, -1, -2]
+        faces = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5]]
+        tags = [-1, -1, -2]
         cells, tag_arrays = _build_boundary_polygons(faces, tags)
         names = sorted(cb.type for cb in cells)
         assert "polygon5" in names
@@ -605,7 +658,7 @@ class TestBuildBoundaryPolygons:
 
     def test_single_polygon_type(self):
         faces = [[0, 1, 2, 3, 4]] * 3
-        tags  = [-1, -1, -2]
+        tags = [-1, -1, -2]
         cells, tag_arrays = _build_boundary_polygons(faces, tags)
         assert len(cells) == 1
         assert cells[0].type == "polygon5"
@@ -613,7 +666,7 @@ class TestBuildBoundaryPolygons:
 
     def test_tags_preserved(self):
         faces = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
-        tags  = [-1, -2]
+        tags = [-1, -2]
         _, tag_arrays = _build_boundary_polygons(faces, tags)
         all_tags = np.concatenate(tag_arrays)
         assert -1 in all_tags
@@ -631,9 +684,7 @@ class TestBuildPolyhedra:
 
     def test_mixed_sizes(self):
         tet_faces = [[0, 1, 2], [0, 1, 3], [1, 2, 3], [0, 2, 3]]
-        pyr_faces = [
-            [0, 1, 2, 3], [0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]
-        ]
+        pyr_faces = [[0, 1, 2, 3], [0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]]
         cells = _build_polyhedra([tet_faces, pyr_faces])
         types = {cb.type for cb in cells}
         assert "polyhedron4" in types
@@ -643,11 +694,9 @@ class TestBuildPolyhedra:
 class TestBuildVolumeCells:
     def test_single_hex(self, hex_cube_data):
         points, faces, owner, neighbour, _ = hex_cube_data
-        owner_arr     = np.array(owner)
+        owner_arr = np.array(owner)
         neighbour_arr = np.array(neighbour, dtype=int)
-        cells = _build_volume_cells(
-            1, faces, owner_arr, neighbour_arr, points
-        )
+        cells = _build_volume_cells(1, faces, owner_arr, neighbour_arr, points)
         hex_blocks = [cb for cb in cells if cb.type == "hexahedron"]
         assert len(hex_blocks) == 1
         assert len(hex_blocks[0].data) == 1
@@ -658,17 +707,30 @@ class TestBuildVolumeCells:
             1, faces, np.array(owner), np.array(neighbour, dtype=int), points
         )
         from meshlane._mesh import CellBlock
+
         assert all(isinstance(cb, CellBlock) for cb in cells)
 
     def test_two_hexes(self):
         """Two hexahedral cells sharing one internal face."""
-        points = np.array([
-            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-            [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
-            [2, 0, 0], [2, 1, 0], [2, 0, 1], [2, 1, 1],
-        ], dtype=float)
+        points = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+                [2, 0, 0],
+                [2, 1, 0],
+                [2, 0, 1],
+                [2, 1, 1],
+            ],
+            dtype=float,
+        )
         faces = [
-            [1, 2, 6, 5],    # internal
+            [1, 2, 6, 5],  # internal
             [0, 3, 2, 1],
             [4, 5, 6, 7],
             [0, 1, 5, 4],
@@ -680,7 +742,7 @@ class TestBuildVolumeCells:
             [2, 9, 11, 6],
             [8, 10, 11, 9],
         ]
-        owner     = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+        owner = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
         neighbour = np.array([1])
         cells = _build_volume_cells(2, faces, owner, neighbour, points)
         n_hex = sum(len(cb.data) for cb in cells if cb.type == "hexahedron")
@@ -712,7 +774,7 @@ class TestBuildBoundaryCells:
     def test_triangle_faces(self, tmp_path):
         """Boundary with triangle faces should produce a 'triangle' CellBlock."""
         faces = [
-            [0, 1, 2],   # triangle boundary face
+            [0, 1, 2],  # triangle boundary face
             [3, 4, 5],
         ]
         boundary = {"tri_patch": {"type": "wall", "nFaces": 2, "startFace": 0}}
@@ -733,7 +795,7 @@ class TestBuildBoundaryCells:
     def test_empty_boundary(self):
         cells, tags, patch_tags = _build_boundary_cells({}, [])
         assert cells == []
-        assert tags  == []
+        assert tags == []
         assert patch_tags == {}
 
 
@@ -774,70 +836,61 @@ class TestDetectFormat:
 
 class TestBinaryReaders:
     def test_read_binary_points(self, tmp_path):
-        pts    = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype="<f8")
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="vectorField", obj="points"
-        )
+        pts = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype="<f8")
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="vectorField", obj="points")
         path = tmp_path / "points"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n2\n")
+            f.write(b"\n2\n(")
             f.write(pts.tobytes())
         read_pts = _read_binary_points(path, scalar_bytes=8)
         np.testing.assert_allclose(read_pts, pts)
 
     def test_read_binary_labels(self, tmp_path):
         labels = np.array([0, 1, 2, 3, 4], dtype="<i4")
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="labelList", obj="owner"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="labelList", obj="owner")
         path = tmp_path / "owner"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n5\n")
+            f.write(b"\n5\n(")
             f.write(labels.tobytes())
         read_lab = _read_binary_labels(path, label_bytes=4)
         np.testing.assert_array_equal(read_lab, labels)
 
     def test_read_binary_faces(self, tmp_path):
-        header     = BINARY_HEADER.format(
-            lab=32, sca=64, cls="faceList", obj="faces"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="faceList", obj="faces")
         faces_data = [[0, 1, 2], [0, 1, 2, 3]]
-        path       = tmp_path / "faces"
+        path = tmp_path / "faces"
+        # Real OpenFOAM faceList: each face is a labelList "M ( <binary> )".
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
             f.write(b"\n2\n(\n")
             for face in faces_data:
-                f.write(f"{len(face)}\n".encode("ascii"))
+                f.write(f"{len(face)}(".encode("ascii"))
                 f.write(np.array(face, dtype="<i4").tobytes())
-                f.write(b"\n")
+                f.write(b")\n")
             f.write(b")\n")
         read_faces = _read_binary_faces(path, label_bytes=4)
-        assert read_faces == faces_data
+        assert read_faces.to_lists() == faces_data
 
     def test_read_binary_points_wrong_size(self, tmp_path):
         """Too few bytes in the file should raise ValueError."""
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="vectorField", obj="points"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="vectorField", obj="points")
         path = tmp_path / "points"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n10\n")
-            f.write(b"\x00" * 8)   # far too few bytes
+            f.write(b"\n10\n(")
+            f.write(b"\x00" * 8)  # far too few bytes
         with pytest.raises(ValueError):
             _read_binary_points(path, scalar_bytes=8)
 
     def test_read_binary_labels_wrong_size(self, tmp_path):
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="labelList", obj="owner"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="labelList", obj="owner")
         path = tmp_path / "owner"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n100\n")
-            f.write(b"\x00" * 4)   # far too few bytes
+            f.write(b"\n100\n(")
+            f.write(b"\x00" * 4)  # far too few bytes
         with pytest.raises(ValueError):
             _read_binary_labels(path, label_bytes=4)
 
@@ -846,63 +899,57 @@ class TestReadDispatchers:
     """Tests for _read_points, _read_faces, _read_int_list (format dispatchers)."""
 
     def test_read_points_ascii(self, tmp_path):
-        pts  = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]])
+        pts = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]])
         path = tmp_path / "points"
         _write_ascii_points(path, pts)
         result = _read_points(path)
         np.testing.assert_allclose(result, pts)
 
     def test_read_points_binary(self, tmp_path):
-        pts    = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="<f8")
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="vectorField", obj="points"
-        )
+        pts = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="<f8")
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="vectorField", obj="points")
         path = tmp_path / "points"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n2\n")
+            f.write(b"\n2\n(")
             f.write(pts.tobytes())
         result = _read_points(path)
         np.testing.assert_allclose(result, pts)
 
     def test_read_faces_ascii(self, tmp_path):
         faces = [[0, 1, 2], [0, 1, 2, 3]]
-        path  = tmp_path / "faces"
+        path = tmp_path / "faces"
         _write_ascii_faces(path, faces)
         result = _read_faces(path)
-        assert result == faces
+        assert result.to_lists() == faces
 
     def test_read_faces_binary(self, tmp_path):
-        header     = BINARY_HEADER.format(
-            lab=32, sca=64, cls="faceList", obj="faces"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="faceList", obj="faces")
         faces_data = [[0, 1, 2]]
-        path       = tmp_path / "faces"
+        path = tmp_path / "faces"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
             f.write(b"\n1\n(\n")
-            f.write(b"3\n")
+            f.write(b"3(")
             f.write(np.array([0, 1, 2], dtype="<i4").tobytes())
-            f.write(b"\n)\n")
+            f.write(b")\n)\n")
         result = _read_faces(path)
-        assert result == faces_data
+        assert result.to_lists() == faces_data
 
     def test_read_int_list_ascii(self, tmp_path):
         labels = [0, 1, 2, 3]
-        path   = tmp_path / "owner"
+        path = tmp_path / "owner"
         _write_ascii_labels(path, labels, "owner")
         result = _read_int_list(path)
         np.testing.assert_array_equal(result, labels)
 
     def test_read_int_list_binary(self, tmp_path):
         labels = np.array([5, 6, 7], dtype="<i4")
-        header = BINARY_HEADER.format(
-            lab=32, sca=64, cls="labelList", obj="owner"
-        )
+        header = BINARY_HEADER.format(lab=32, sca=64, cls="labelList", obj="owner")
         path = tmp_path / "owner"
         with open(path, "wb") as f:
             f.write(header.encode("ascii"))
-            f.write(b"\n3\n")
+            f.write(b"\n3\n(")
             f.write(labels.tobytes())
         result = _read_int_list(path)
         np.testing.assert_array_equal(result, labels)
@@ -994,13 +1041,14 @@ class TestPublicAPI:
             capture_output=True,
             text=True,
         )
-        assert result.returncode == 0, (
-            f"meshlane.read('*.foam') failed via public API:\n{result.stderr}"
-        )
+        assert (
+            result.returncode == 0
+        ), f"meshlane.read('*.foam') failed via public API:\n{result.stderr}"
 
     def test_openfoam_read_exposed(self):
         """meshlane.openfoam.read must exist (package __init__ ran)."""
         import meshlane
+
         assert hasattr(meshlane.openfoam, "read")
 
 
@@ -1009,11 +1057,23 @@ class TestReadTwoCellMesh:
 
     @pytest.fixture
     def two_hex_case(self, tmp_path):
-        points = np.array([
-            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-            [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
-            [2, 0, 0], [2, 1, 0], [2, 0, 1], [2, 1, 1],
-        ], dtype=float)
+        points = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+                [2, 0, 0],
+                [2, 1, 0],
+                [2, 0, 1],
+                [2, 1, 1],
+            ],
+            dtype=float,
+        )
 
         faces = [
             [1, 2, 6, 5],
@@ -1028,9 +1088,9 @@ class TestReadTwoCellMesh:
             [2, 9, 11, 6],
             [8, 10, 11, 9],
         ]
-        owner     = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+        owner = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
         neighbour = [1]
-        boundary  = {"walls": {"type": "wall", "nFaces": 10, "startFace": 1}}
+        boundary = {"walls": {"type": "wall", "nFaces": 10, "startFace": 1}}
 
         poly = tmp_path / "constant" / "polyMesh"
         poly.mkdir(parents=True)
@@ -1046,7 +1106,8 @@ class TestReadTwoCellMesh:
         mesh = read(two_hex_case / "case.foam")
         assert mesh.points.shape == (12, 3)
         n_vol = sum(
-            len(cb.data) for cb in mesh.cells
+            len(cb.data)
+            for cb in mesh.cells
             if cb.type in ("tetra", "pyramid", "wedge", "hexahedron")
             or cb.type.startswith("polyhedron")
         )
@@ -1066,15 +1127,13 @@ class TestReadTwoCellMesh:
 
 
 class TestRobustness:
-    def test_find_n_with_comments(self, tmp_path):
+    def test_data_start_finds_count(self, tmp_path):
         content = (
-            ASCII_HEADER.format(cls="x", obj="y")
-            + "\n// comment\n/* block */\n5\n(\ndata\n"
+            BINARY_HEADER.format(lab=32, sca=64, cls="x", obj="y") + "\n5\n(binary"
         )
         path = tmp_path / "f"
         path.write_text(content)
-        raw     = path.read_bytes()
-        n, pos  = _find_n_and_data_start(raw, skip_paren=True)
+        n, pos = _data_start(path.read_bytes())
         assert n == 5
 
     def test_parse_boundary_empty(self):
@@ -1082,12 +1141,12 @@ class TestRobustness:
 
     def test_parse_points_malformed(self):
         lines = ["1", "(", "(1 2)", ")"]
-        pts   = _parse_points_ascii(lines)
+        pts = _parse_points_ascii(lines)
         assert len(pts) == 0
 
-    def test_build_cell_to_faces_zero_cells(self):
-        cf = _build_cell_to_faces(0, np.array([], dtype=int), np.array([], dtype=int))
-        assert cf == []
+    def test_cell_faces_csr_zero_cells(self):
+        cf = _cell_faces_csr(0, np.array([], dtype=int), np.array([], dtype=int))
+        assert len(cf) == 0
 
     def test_strip_comments_only_comment(self):
         assert _strip_comments("/* entire line */").strip() == ""
@@ -1102,7 +1161,7 @@ class TestRobustness:
 
     def test_build_boundary_cells_out_of_range_face(self):
         """startFace + nFaces beyond faces list length must not crash."""
-        faces    = [[0, 1, 2, 3]]
+        faces = [[0, 1, 2, 3]]
         boundary = {"p": {"type": "wall", "nFaces": 10, "startFace": 0}}
         cells, tags, patch_tags = _build_boundary_cells(boundary, faces)
         # Only the one valid face should be included


### PR DESCRIPTION

Reading a large binary polyMesh could consume all available memory and eventually render the host unresponsive. There were two causes. First, the binary faceList parser expected the layout `M <binary>`, whereas OpenFOAM writes each face as `M(<binary> )`. The parser read the opening parenthesis as node data and lost alignment for allsubsequent faces. Second, faces and cell topology were stored as Python lists of lists, which is memory-inefficient for large meshes.

This change stores faces and cell-to-face connectivity as flat NumPy arrays  in CSR form, corrects the binary faceList parser to handle the actual format, and constructs the cell-to-face mapping with vectorized NumPy. The per-cell reconstruction logic is unchanged.

Memory use is now bounded, reading completes reliably on large meshes and all 105 OpenFOAM tests pass.

