### PR TITLE
fix(med): node ordering for 3D cells (meshlane <--> MED orientation)

### DIFF
--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -8,7 +8,7 @@ import re
 
 from ._med41 import FieldBitmaskWriter
 
-from .._common import num_nodes_per_cell
+from .._common import num_nodes_per_cell, warn
 from .._exceptions import ReadError, WriteError
 from .._helpers import register_format
 from collections import defaultdict
@@ -53,6 +53,32 @@ _med_node_perm = {
     "wedge": [3, 4, 5, 0, 1, 2],
     "hexahedron": [4, 5, 6, 7, 0, 1, 2, 3],
 }
+
+# Quadratic 3D types have the same meshio<->MED orientation difference, but their
+# permutations (corners + edge-midpoints) are not implemented yet. They are
+# written without conversion and so may be mis-oriented for MED readers; warn.
+_med_unconverted_3d = {"tetra10", "hexahedron20", "pyramid13", "wedge15"}
+
+
+def _reorder_med_cells(cell_type, data):
+    """Apply the self-inverse meshio <-> MED node permutation to a (n, k) cell
+    array (no-op for types not in ``_med_node_perm``). Shared by the reader and
+    both writers (single-mesh and multi-mesh) so the paths cannot drift."""
+    perm = _med_node_perm.get(cell_type)
+    return data[:, perm] if perm is not None else data
+
+
+def _med_cells_for_write(cell_type, data):
+    """Like :func:`_reorder_med_cells`, for the write paths: additionally warn
+    when a quadratic 3D type is written without orientation conversion."""
+    if cell_type in _med_unconverted_3d:
+        warn(
+            f"MED: quadratic 3D cells '{cell_type}' are not yet written with the "
+            "meshio->MED orientation conversion and may be mis-oriented for MED "
+            "readers (Salome, code_saturne, code_aster, etc.)."
+        )
+    return _reorder_med_cells(cell_type, data)
+
 
 numpy_void_str = np.bytes_("")
 
@@ -343,9 +369,7 @@ def read(filename):
             nod = med_cell_type_group["NOD"]
             n_cells = nod.attrs["NBR"]
             data = nod[()].reshape(n_cells, -1, order="F") - 1
-            perm = _med_node_perm.get(cell_type)
-            if perm is not None:  # MED -> meshio node order (orientation)
-                data = data[:, perm]
+            data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
             cells += [(cell_type, data)]
 
         # Cell tags
@@ -680,9 +704,7 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
         else:
             # Merge cells of the same type
             merged_cells = np.concatenate(cells_list, axis=0)
-            perm = _med_node_perm.get(cell_type)
-            if perm is not None:  # meshio -> MED node order (orientation)
-                merged_cells = merged_cells[:, perm]
+            merged_cells = _med_cells_for_write(cell_type, merged_cells)  # meshio -> MED
             nod = med_cells.create_dataset("NOD", data=merged_cells.flatten(order="F") + 1)
             nod.attrs.create("CGT", 1)
             nod.attrs.create("NBR", len(merged_cells))

--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -37,6 +37,22 @@ meshio_to_med_type = {
     "polygon2": "POG2",
 }
 med_to_meshio_type = {v: k for k, v in meshio_to_med_type.items()}
+
+# meshio uses VTK (positive-orientation) node ordering for 3D cells; MED/Salome
+# use the opposite orientation (verified against real .med files: the element
+# corner Jacobian is negative in MED, positive in meshio). These
+# structure-preserving, self-inverse permutations convert between the two.
+# Applied on BOTH read and write, so the in-memory mesh stays in meshio
+# convention and MED->MED round-trips are the identity, while meshio->MED output
+# (e.g. from OpenFOAM/Abaqus) is correctly oriented for MED readers such as
+# Salome and code_saturne.
+_med_node_perm = {
+    "tetra": [0, 1, 3, 2],
+    "pyramid": [0, 3, 2, 1, 4],
+    "wedge": [3, 4, 5, 0, 1, 2],
+    "hexahedron": [4, 5, 6, 7, 0, 1, 2, 3],
+}
+
 numpy_void_str = np.bytes_("")
 
 MED_FLOAT32 = 4
@@ -325,7 +341,11 @@ def read(filename):
         else:
             nod = med_cell_type_group["NOD"]
             n_cells = nod.attrs["NBR"]
-            cells += [(cell_type, nod[()].reshape(n_cells, -1, order="F") - 1)]
+            data = nod[()].reshape(n_cells, -1, order="F") - 1
+            perm = _med_node_perm.get(cell_type)
+            if perm is not None:  # MED -> meshio node order (orientation)
+                data = data[:, perm]
+            cells += [(cell_type, data)]
 
         # Cell tags
         if "FAM" in med_cell_type_group:
@@ -659,6 +679,9 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
         else:
             # Merge cells of the same type
             merged_cells = np.concatenate(cells_list, axis=0)
+            perm = _med_node_perm.get(cell_type)
+            if perm is not None:  # meshio -> MED node order (orientation)
+                merged_cells = merged_cells[:, perm]
             nod = med_cells.create_dataset("NOD", data=merged_cells.flatten(order="F") + 1)
             nod.attrs.create("CGT", 1)
             nod.attrs.create("NBR", len(merged_cells))

--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -38,13 +38,13 @@ meshio_to_med_type = {
 }
 med_to_meshio_type = {v: k for k, v in meshio_to_med_type.items()}
 
-# meshio uses VTK node ordering for 3D cells; MED uses the same node structure
+# meshlane uses VTK node ordering for 3D cells; MED uses the same node structure
 # but the opposite orientation (winding). These structure-preserving,
-# self-inverse permutations convert meshio <-> MED. They are derived so that,
-# after permutation, every face defined by MEDCoupling's INTERP_KERNEL cell model
+# self-inverse permutations convert meshlane (VTK) <-> MED. They are derived so
+# that after permutation, every face defined by MEDCoupling's INTERP_KERNEL model
 # (SalomePlatform/medcoupling, CellModel.cxx) has an outward normal -- i.e. a
 # valid MED cell. Applied on BOTH read and write, so the in-memory mesh stays in
-# meshio convention and MED->MED round-trips are the identity, while meshio->MED
+# meshlane convention and MED->MED round-trips are the identity, while meshlane->MED
 # output (e.g. from OpenFOAM/Abaqus) is correctly oriented for MED readers such
 # as Salome and code_saturne.
 _med_node_perm = {
@@ -54,7 +54,7 @@ _med_node_perm = {
     "hexahedron": [4, 5, 6, 7, 0, 1, 2, 3],
 }
 
-# Quadratic 3D types have the same meshio<->MED orientation difference, but their
+# Quadratic 3D types have the same meshlane<->MED orientation difference, but their
 # permutations (corners + edge-midpoints) are not implemented yet, so they are
 # left unconverted in both directions (read and write) and may be mis-oriented.
 _med_unconverted_3d = {"tetra10", "hexahedron20", "pyramid13", "wedge15"}
@@ -62,7 +62,7 @@ _med_unconverted_3d = {"tetra10", "hexahedron20", "pyramid13", "wedge15"}
 
 def _warn_unconverted_3d(cell_type):
     """Warn that a quadratic 3D cell type is being read or written without the
-    meshio <-> MED node-ordering conversion (not implemented for these types
+    meshlane <-> MED node-ordering conversion (not implemented for these types
     yet), so it may be mis-oriented. Called on both read and write."""
     if cell_type in _med_unconverted_3d:
         warn(
@@ -73,7 +73,7 @@ def _warn_unconverted_3d(cell_type):
 
 
 def _reorder_med_cells(cell_type, data):
-    """Apply the self-inverse meshio <-> MED node permutation to a (n, k) cell
+    """Apply the self-inverse meshlane <-> MED node permutation to a (n, k) cell
     array (no-op for types not in ``_med_node_perm``). Shared by the reader and
     both writers (single-mesh and multi-mesh) so the paths cannot drift."""
     perm = _med_node_perm.get(cell_type)
@@ -377,7 +377,7 @@ def read(filename):
             n_cells = nod.attrs["NBR"]
             data = nod[()].reshape(n_cells, -1, order="F") - 1
             _warn_unconverted_3d(cell_type)
-            data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
+            data = _reorder_med_cells(cell_type, data)  # MED -> meshlane order
             cells += [(cell_type, data)]
 
         # Cell tags
@@ -712,7 +712,7 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
         else:
             # Merge cells of the same type
             merged_cells = np.concatenate(cells_list, axis=0)
-            merged_cells = _med_cells_for_write(cell_type, merged_cells)  # meshio -> MED
+            merged_cells = _med_cells_for_write(cell_type, merged_cells)  # meshlane -> MED
             nod = med_cells.create_dataset("NOD", data=merged_cells.flatten(order="F") + 1)
             nod.attrs.create("CGT", 1)
             nod.attrs.create("NBR", len(merged_cells))

--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -55,9 +55,21 @@ _med_node_perm = {
 }
 
 # Quadratic 3D types have the same meshio<->MED orientation difference, but their
-# permutations (corners + edge-midpoints) are not implemented yet. They are
-# written without conversion and so may be mis-oriented for MED readers; warn.
+# permutations (corners + edge-midpoints) are not implemented yet, so they are
+# left unconverted in both directions (read and write) and may be mis-oriented.
 _med_unconverted_3d = {"tetra10", "hexahedron20", "pyramid13", "wedge15"}
+
+
+def _warn_unconverted_3d(cell_type):
+    """Warn that a quadratic 3D cell type is being read or written without the
+    meshio <-> MED node-ordering conversion (not implemented for these types
+    yet), so it may be mis-oriented. Called on both read and write."""
+    if cell_type in _med_unconverted_3d:
+        warn(
+            f"MED: orientation conversion for quadratic 3D cells '{cell_type}' is "
+            "not yet implemented. These cells may be mis-oriented for MED tools "
+            "(Salome, code_saturne, code_aster, etc.)."
+        )
 
 
 def _reorder_med_cells(cell_type, data):
@@ -70,13 +82,8 @@ def _reorder_med_cells(cell_type, data):
 
 def _med_cells_for_write(cell_type, data):
     """Like :func:`_reorder_med_cells`, for the write paths: additionally warn
-    when a quadratic 3D type is written without orientation conversion."""
-    if cell_type in _med_unconverted_3d:
-        warn(
-            f"MED: quadratic 3D cells '{cell_type}' are not yet written with the "
-            "meshio->MED orientation conversion and may be mis-oriented for MED "
-            "readers (Salome, code_saturne, code_aster, etc.)."
-        )
+    for unconverted quadratic 3D types."""
+    _warn_unconverted_3d(cell_type)
     return _reorder_med_cells(cell_type, data)
 
 
@@ -369,6 +376,7 @@ def read(filename):
             nod = med_cell_type_group["NOD"]
             n_cells = nod.attrs["NBR"]
             data = nod[()].reshape(n_cells, -1, order="F") - 1
+            _warn_unconverted_3d(cell_type)
             data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
             cells += [(cell_type, data)]
 

--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -38,14 +38,15 @@ meshio_to_med_type = {
 }
 med_to_meshio_type = {v: k for k, v in meshio_to_med_type.items()}
 
-# meshio uses VTK (positive-orientation) node ordering for 3D cells; MED/Salome
-# use the opposite orientation (verified against real .med files: the element
-# corner Jacobian is negative in MED, positive in meshio). These
-# structure-preserving, self-inverse permutations convert between the two.
-# Applied on BOTH read and write, so the in-memory mesh stays in meshio
-# convention and MED->MED round-trips are the identity, while meshio->MED output
-# (e.g. from OpenFOAM/Abaqus) is correctly oriented for MED readers such as
-# Salome and code_saturne.
+# meshio uses VTK node ordering for 3D cells; MED uses the same node structure
+# but the opposite orientation (winding). These structure-preserving,
+# self-inverse permutations convert meshio <-> MED. They are derived so that,
+# after permutation, every face defined by MEDCoupling's INTERP_KERNEL cell model
+# (SalomePlatform/medcoupling, CellModel.cxx) has an outward normal -- i.e. a
+# valid MED cell. Applied on BOTH read and write, so the in-memory mesh stays in
+# meshio convention and MED->MED round-trips are the identity, while meshio->MED
+# output (e.g. from OpenFOAM/Abaqus) is correctly oriented for MED readers such
+# as Salome and code_saturne.
 _med_node_perm = {
     "tetra": [0, 1, 3, 2],
     "pyramid": [0, 3, 2, 1, 4],

--- a/src/meshlane/med/_medmulti.py
+++ b/src/meshlane/med/_medmulti.py
@@ -481,7 +481,7 @@ def _read_single_mesh(f, name):
             n_cells = nod.attrs["NBR"]
             data = nod[()].reshape(n_cells, -1, order="F") - 1
             _warn_unconverted_3d(cell_type)
-            data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
+            data = _reorder_med_cells(cell_type, data)  # MED -> meshlane order
             cells += [(cell_type, data)]
 
         if "FAM" in med_cell_type_group:

--- a/src/meshlane/med/_medmulti.py
+++ b/src/meshlane/med/_medmulti.py
@@ -34,6 +34,8 @@ from ._med import (
     numpy_to_med_type,
     numpy_void_str,
     MED_FLOAT64,
+    _med_cells_for_write,
+    _reorder_med_cells,
     _write_families,
     _read_families,
     _read_data,
@@ -342,6 +344,7 @@ def _write_med_multi(filename, meshes, mesh_names=None, med_version="4.1.0", **k
                 n_merged = len(all_polygons)
             else:
                 merged_cells = np.concatenate(cells_list, axis=0)
+                merged_cells = _med_cells_for_write(cell_type, merged_cells)
                 nod = med_cells.create_dataset(
                     "NOD", data=merged_cells.flatten(order="F") + 1
                 )
@@ -475,7 +478,9 @@ def _read_single_mesh(f, name):
         else:
             nod = med_cell_type_group["NOD"]
             n_cells = nod.attrs["NBR"]
-            cells += [(cell_type, nod[()].reshape(n_cells, -1, order="F") - 1)]
+            data = nod[()].reshape(n_cells, -1, order="F") - 1
+            data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
+            cells += [(cell_type, data)]
 
         if "FAM" in med_cell_type_group:
             cell_data.setdefault("cell_tags", []).append(

--- a/src/meshlane/med/_medmulti.py
+++ b/src/meshlane/med/_medmulti.py
@@ -36,6 +36,7 @@ from ._med import (
     MED_FLOAT64,
     _med_cells_for_write,
     _reorder_med_cells,
+    _warn_unconverted_3d,
     _write_families,
     _read_families,
     _read_data,
@@ -479,6 +480,7 @@ def _read_single_mesh(f, name):
             nod = med_cell_type_group["NOD"]
             n_cells = nod.attrs["NBR"]
             data = nod[()].reshape(n_cells, -1, order="F") - 1
+            _warn_unconverted_3d(cell_type)
             data = _reorder_med_cells(cell_type, data)  # MED -> meshio order
             cells += [(cell_type, data)]
 

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1360,47 +1360,69 @@ def test_med_multi_hdf5_structure(tmp_path):
         assert "INFOS_GENERALES" in f, "INFOS_GENERALES must exist"
 
 
+# Reference cells in meshio/VTK ordering + the MED (MEDCoupling INTERP_KERNEL
+# CellModel.cxx) face definitions for each 3D type.
+_MED_ORIENT_REF = {
+    "tetra": (
+        np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], float),
+        [[0, 1, 2], [0, 3, 1], [1, 3, 2], [2, 3, 0]],
+    ),
+    "pyramid": (
+        np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0.5, 0.5, 1]], float),
+        [[0, 1, 2, 3], [0, 4, 1], [1, 4, 2], [2, 4, 3], [3, 4, 0]],
+    ),
+    "wedge": (
+        np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1]], float
+        ),
+        [[0, 1, 2], [3, 5, 4], [0, 3, 4, 1], [1, 4, 5, 2], [2, 5, 3, 0]],
+    ),
+    "hexahedron": (
+        np.array(
+            [
+                [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+                [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+            ],
+            float,
+        ),
+        [[0, 1, 2, 3], [4, 7, 6, 5], [0, 4, 5, 1],
+         [1, 5, 6, 2], [2, 6, 7, 3], [3, 7, 4, 0]],
+    ),
+}
+
+
+def _all_med_faces_outward(pts, perm, med_faces):
+    """True iff, after applying ``perm``, every MED-defined face points outward."""
+    h = pts[perm]
+    centroid = h.mean(axis=0)
+    for f in med_faces:
+        fp = h[f]
+        normal = np.cross(fp[1] - fp[0], fp[2] - fp[0])
+        if np.dot(normal, fp.mean(axis=0) - centroid) <= 0:
+            return False
+    return True
+
+
 def test_med_node_perm_matches_medcoupling_faces():
-    """The meshio<->MED 3D node permutations must produce valid MED cells:
-    after permutation, every face defined by MEDCoupling's INTERP_KERNEL cell
-    model (CellModel.cxx) must have an outward normal. This pins the ordering
-    to the authoritative MED source, independent of any reference .med file."""
+    """The meshio<->MED 3D node permutations must produce valid MED cells: after
+    permutation, every face defined by MEDCoupling's INTERP_KERNEL cell model
+    (CellModel.cxx) must point outward. Pins the ordering to the authoritative
+    MED source, independent of any reference .med file."""
     from meshlane.med._med import _med_node_perm
 
-    # reference cells in meshio/VTK ordering
-    ref = {
-        "tetra": (
-            np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], float),
-            [[0, 1, 2], [0, 3, 1], [1, 3, 2], [2, 3, 0]],
-        ),
-        "pyramid": (
-            np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0.5, 0.5, 1]], float),
-            [[0, 1, 2, 3], [0, 4, 1], [1, 4, 2], [2, 4, 3], [3, 4, 0]],
-        ),
-        "wedge": (
-            np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1]], float
-            ),
-            [[0, 1, 2], [3, 5, 4], [0, 3, 4, 1], [1, 4, 5, 2], [2, 5, 3, 0]],
-        ),
-        "hexahedron": (
-            np.array(
-                [
-                    [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
-                    [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
-                ],
-                float,
-            ),
-            [[0, 1, 2, 3], [4, 7, 6, 5], [0, 4, 5, 1],
-             [1, 5, 6, 2], [2, 6, 7, 3], [3, 7, 4, 0]],
-        ),
-    }
-    for cell_type, (pts, med_faces) in ref.items():
-        h = pts[_med_node_perm[cell_type]]
-        centroid = h.mean(axis=0)
-        for f in med_faces:
-            fp = h[f]
-            normal = np.cross(fp[1] - fp[0], fp[2] - fp[0])
-            assert np.dot(normal, fp.mean(axis=0) - centroid) > 0, (
-                f"{cell_type} face {f} not outward after permutation"
-            )
+    for cell_type, (pts, med_faces) in _MED_ORIENT_REF.items():
+        assert _all_med_faces_outward(pts, _med_node_perm[cell_type], med_faces), (
+            f"{cell_type}: MED faces not all outward after permutation"
+        )
+
+
+def test_identity_perm_is_not_med_orientation():
+    """Negative control: the identity permutation must NOT yield valid MED cells.
+    Guards against a future change silently dropping a permutation to
+    [0, 1, 2, ...] (meshio order), which would still be wrong for MED."""
+    for cell_type, (pts, med_faces) in _MED_ORIENT_REF.items():
+        identity = list(range(len(pts)))
+        assert not _all_med_faces_outward(pts, identity, med_faces), (
+            f"{cell_type}: identity permutation unexpectedly passed the MED "
+            "outward-face check (the check is not discriminating)"
+        )

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1360,7 +1360,7 @@ def test_med_multi_hdf5_structure(tmp_path):
         assert "INFOS_GENERALES" in f, "INFOS_GENERALES must exist"
 
 
-# Reference cells in meshio/VTK ordering + the MED (MEDCoupling INTERP_KERNEL
+# Reference cells in meshlane (VTK) ordering + the MED (MEDCoupling INTERP_KERNEL
 # CellModel.cxx) face definitions for each 3D type.
 _MED_ORIENT_REF = {
     "tetra": (
@@ -1404,7 +1404,7 @@ def _all_med_faces_outward(pts, perm, med_faces):
 
 
 def test_med_node_perm_matches_medcoupling_faces():
-    """The meshio<->MED 3D node permutations must produce valid MED cells: after
+    """The meshlane<->MED 3D node permutations must produce valid MED cells: after
     permutation, every face defined by MEDCoupling's INTERP_KERNEL cell model
     (CellModel.cxx) must point outward. Pins the ordering to the authoritative
     MED source, independent of any reference .med file."""
@@ -1419,7 +1419,7 @@ def test_med_node_perm_matches_medcoupling_faces():
 def test_identity_perm_is_not_med_orientation():
     """Negative control: the identity permutation must NOT yield valid MED cells.
     Guards against a future change silently dropping a permutation to
-    [0, 1, 2, ...] (meshio order), which would still be wrong for MED."""
+    [0, 1, 2, ...] (meshlane order), which would still be wrong for MED."""
     for cell_type, (pts, med_faces) in _MED_ORIENT_REF.items():
         identity = list(range(len(pts)))
         assert not _all_med_faces_outward(pts, identity, med_faces), (
@@ -1441,7 +1441,7 @@ def test_med_multi_3d_orientation_and_roundtrip(tmp_path):
         ],
         float,
     )
-    hexa = np.array([[0, 1, 2, 3, 4, 5, 6, 7]])  # meshio (positive) order
+    hexa = np.array([[0, 1, 2, 3, 4, 5, 6, 7]])  # meshlane (positive) order
     m1 = Mesh(pts, [CellBlock("hexahedron", hexa.copy())])
     m2 = Mesh(pts + 2.0, [CellBlock("hexahedron", hexa.copy())])
 

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1426,3 +1426,45 @@ def test_identity_perm_is_not_med_orientation():
             f"{cell_type}: identity permutation unexpectedly passed the MED "
             "outward-face check (the check is not discriminating)"
         )
+
+
+def test_med_multi_3d_orientation_and_roundtrip(tmp_path):
+    """Multi-mesh MED: 3D cells are written in MED orientation, and the
+    multi-mesh reader applies the inverse permutation so a write->read round-trip
+    is identity. Exercises the multi-mesh write AND read directions."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    pts = np.array(
+        [
+            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+            [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+        ],
+        float,
+    )
+    hexa = np.array([[0, 1, 2, 3, 4, 5, 6, 7]])  # meshio (positive) order
+    m1 = Mesh(pts, [CellBlock("hexahedron", hexa.copy())])
+    m2 = Mesh(pts + 2.0, [CellBlock("hexahedron", hexa.copy())])
+
+    filename = tmp_path / "multi.med"
+    meshlane.med.write_med_multi(filename, [m1, m2], mesh_names=["a", "b"])
+
+    # on-disk: hexes are in MED (negative-orientation) order for BOTH meshes
+    def corner_jac(conn, P):
+        return float(
+            np.dot(P[conn[1]] - P[conn[0]],
+                   np.cross(P[conn[3]] - P[conn[0]], P[conn[4]] - P[conn[0]]))
+        )
+
+    with h5py.File(filename, "r") as f:
+        for name, P in (("a", pts), ("b", pts + 2.0)):
+            m = f["ENS_MAA"][name]
+            if "NOE" not in m:
+                m = m[list(m.keys())[0]]
+            conn = m["MAI"]["HE8"]["NOD"][()].reshape(1, -1, order="F") - 1
+            assert corner_jac(conn[0], P) < 0, f"{name}: hex not MED-oriented on disk"
+
+    # multi-mesh read applies the inverse perm -> round-trip identity
+    meshes, names = meshlane.med.read_med_multi(filename)
+    by_name = dict(zip(names, meshes))
+    for name, orig in (("a", m1), ("b", m2)):
+        np.testing.assert_array_equal(orig.cells[0].data, by_name[name].cells[0].data)

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1358,3 +1358,49 @@ def test_med_multi_hdf5_structure(tmp_path):
         assert "alpha" in f["FAS"], "alpha must be in FAS"
         assert "beta" in f["FAS"], "beta must be in FAS"
         assert "INFOS_GENERALES" in f, "INFOS_GENERALES must exist"
+
+
+def test_med_node_perm_matches_medcoupling_faces():
+    """The meshio<->MED 3D node permutations must produce valid MED cells:
+    after permutation, every face defined by MEDCoupling's INTERP_KERNEL cell
+    model (CellModel.cxx) must have an outward normal. This pins the ordering
+    to the authoritative MED source, independent of any reference .med file."""
+    from meshlane.med._med import _med_node_perm
+
+    # reference cells in meshio/VTK ordering
+    ref = {
+        "tetra": (
+            np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], float),
+            [[0, 1, 2], [0, 3, 1], [1, 3, 2], [2, 3, 0]],
+        ),
+        "pyramid": (
+            np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0.5, 0.5, 1]], float),
+            [[0, 1, 2, 3], [0, 4, 1], [1, 4, 2], [2, 4, 3], [3, 4, 0]],
+        ),
+        "wedge": (
+            np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 0, 1], [0, 1, 1]], float
+            ),
+            [[0, 1, 2], [3, 5, 4], [0, 3, 4, 1], [1, 4, 5, 2], [2, 5, 3, 0]],
+        ),
+        "hexahedron": (
+            np.array(
+                [
+                    [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+                    [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+                ],
+                float,
+            ),
+            [[0, 1, 2, 3], [4, 7, 6, 5], [0, 4, 5, 1],
+             [1, 5, 6, 2], [2, 6, 7, 3], [3, 7, 4, 0]],
+        ),
+    }
+    for cell_type, (pts, med_faces) in ref.items():
+        h = pts[_med_node_perm[cell_type]]
+        centroid = h.mean(axis=0)
+        for f in med_faces:
+            fp = h[f]
+            normal = np.cross(fp[1] - fp[0], fp[2] - fp[0])
+            assert np.dot(normal, fp.mean(axis=0) - centroid) > 0, (
+                f"{cell_type} face {f} not outward after permutation"
+            )


### PR DESCRIPTION
## Issue
meshlaneuses VTK node ordering for 3D cells. MED uses the same node *structure* (first/last face + vertical edges) but the opposite *orientation* (face winding). The MED reader and writer never converted between the two, so connectivity was written and read as-is. Two consequences:
- **Write**: meshes from other formats (OpenFOAM, Abaqus) were written to MED with inverted 3D cells. Even though the mesh opened correctly in Salome, it crashed code_saturne. The latter's preprocessor reported all tetrahedra "re-oriented", pyramids/prisms/hexahedra "mis-oriented or highly warped", then a fatal face with cell connectivity errors.
- **Read**: MED files were read without conversion, so converting them to another format produced inverted cells too.

The cells themselves were correct (valid meshlane-convention elements); only the orientation convention differed. MED to MED round-trips were unaffected because both sides used the same (unconverted) ordering.

## Fix
Add structure-preserving, self-inverse node permutations that convert 3D-cell node ordering between meshlaneand MED, applied on **both read and write** and on **both** the single-mesh and multi-mesh paths (through a shared helper so they can't drift):
- tetra `[0, 1, 3, 2]`
- pyramid `[0, 3, 2, 1, 4]`
- wedge `[3, 4, 5, 0, 1, 2]`
- hexahedron `[4, 5, 6, 7, 0, 1, 2, 3]`

The permutations come from MEDCoupling's `INTERP_KERNEL` cell definitions (`CellModel.cxx`): after permutation, every face defined there for the element has an outward normal, i.e. a valid MED cell. Being self-inverse and applied on both paths, the in-memory mesh stays in meshlaneconvention, MED to MED round-trips remain the identity, and meshlaneto MED output is correctly oriented for MED readers.

## Verification
- Derived and checked against MEDCoupling's `CellModel.cxx` face definitions: for each 3D type, the permutation produces a cell whose MED-defined faces all point outward. A regression test pins this (no external file). A negative-control test asserts the identity permutation fails the same check.
- A multi-mesh test asserts the write-to-read round-trip is identity and the on-disk 3D cells are MED-oriented, exercising the multi-mesh write and read directions.
- Cross-checked against a code_saturne-validated reference `.med`: every 3D cell orientation now matches.
- An OpenFOAM case converted to MED now has all 3D cell orientations matching that reference.
- MED to MED round-trip is byte-identical connectivity.

## Scope / follow-ups
- Covers the linear 3D types (tetra, pyramid, wedge, hexahedron), on single- and multi-mesh read and write.
- Quadratic 3D types (tetra10, hexahedron20, pyramid13, wedge15) have the same orientation difference but are **not yet converted in either direction**: reading or writing them emits a warning. Their permutations (corners + edge-midpoints) are derivable from the same MEDCoupling `CellModel.cxx` and may be planned for a follow-up.