### PR TITLE
fix(med): Preserve Gmsh physical groups when writing MED

### DIFF
--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -235,8 +235,17 @@ def _ensure_med_families(mesh):
 
         point_data["point_tags"] = point_fam_array
 
-    # cell_sets → element families (negative ids, per MED spec)
-    if not has_cell_tags and mesh.cell_sets:
+    # cell_sets / gmsh:physical → element families (negative ids, per MED spec).
+    #
+    # Two group conventions feed this: named cell_sets (Abaqus ELSET, Ansys,
+    # FLAC3D, Gmsh 4.1 $PhysicalNames, MED) and Gmsh's cell_data array
+    # "gmsh:physical" (one integer physical id per cell — Gmsh 2.2/4.0, MDPA,
+    # and un-named Gmsh 4.1 groups). Both are folded into the same per-cell
+    # group map so a cell belonging to several groups still gets one combined
+    # family. Without the gmsh:physical path a .msh converted to .med would
+    # silently lose every group.
+    gmsh_physical = cell_data.get("gmsh:physical")
+    if not has_cell_tags and (mesh.cell_sets or gmsh_physical is not None):
         n_blocks = len(mesh.cells)
 
         # One family-id array per cell block, initialised to 0
@@ -245,19 +254,47 @@ def _ensure_med_families(mesh):
         ]
 
         # Accumulate group names per (block_idx, local_cell_idx)
-        # cell_sets[set_name] is a list of length n_blocks;
-        # cell_sets[set_name][block_idx] is an array of local indices.
         cell_groups_map: list[list[set]] = [
             [set() for _ in range(len(cb.data))] for cb in mesh.cells
         ]
 
-        for set_name, per_block in mesh.cell_sets.items():
+        # Named cell_sets. cell_sets[set_name] is a list of length n_blocks;
+        # cell_sets[set_name][block_idx] is an array of local indices.
+        for set_name, per_block in (mesh.cell_sets or {}).items():
             for block_idx, indices in enumerate(per_block):
                 if indices is None or len(indices) == 0:
                     continue
                 for local_i in np.asarray(indices, dtype=np.int64):
                     if 0 <= local_i < len(cell_groups_map[block_idx]):
                         cell_groups_map[block_idx][local_i].add(set_name)
+
+        # Gmsh physical ids, for ids NOT already exposed as a named cell_set
+        # (avoids a duplicate group when Gmsh 4.1 carried both). The readable
+        # name is field_data's name for that id, else "group_<id>".
+        if gmsh_physical is not None:
+            id_to_name = {}
+            for gname, val in (mesh.field_data or {}).items():
+                arr = np.asarray(val).ravel()
+                if arr.size >= 1:
+                    try:
+                        id_to_name[int(arr[0])] = gname
+                    except (ValueError, TypeError):
+                        continue
+
+            for block_idx, cb in enumerate(mesh.cells):
+                if block_idx >= len(gmsh_physical) or gmsh_physical[block_idx] is None:
+                    continue
+                block_phys = np.asarray(gmsh_physical[block_idx]).ravel()
+                for local_i in range(len(cb.data)):
+                    pid = int(block_phys[local_i])
+                    if pid == 0:
+                        continue  # family 0 — no group
+                    name = id_to_name.get(pid)
+                    if name is not None and name in (mesh.cell_sets or {}):
+                        continue  # already captured as a named cell_set
+                    if name is None:
+                        name = f"group_{pid}"
+                    cell_groups_map[block_idx][local_i].add(name)
 
         combo_to_fam_cell: dict = {}
         next_cell_fam = -1  # element families: negative (MED spec)
@@ -281,7 +318,7 @@ def _ensure_med_families(mesh):
 
         cell_data["cell_tags"] = cell_fam_arrays
 
-    # Rebuild the Mesh with the enriched data 
+    # Rebuild the Mesh with the enriched data
     out = Mesh(
         points=mesh.points,
         cells=mesh.cells,

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1468,3 +1468,87 @@ def test_med_multi_3d_orientation_and_roundtrip(tmp_path):
     by_name = dict(zip(names, meshes))
     for name, orig in (("a", m1), ("b", m2)):
         np.testing.assert_array_equal(orig.cells[0].data, by_name[name].cells[0].data)
+
+
+def test_gmsh_physical_groups_written_as_med_families(tmp_path):
+    """Gmsh stores groups as cell_data["gmsh:physical"] (an integer id per
+    cell), not as cell_sets. The MED writer must bridge these into MED
+    families/groups, otherwise a .msh -> .med conversion drops all groups.
+    Here two blocks carry distinct physical ids and no names -> fallback
+    "group_<id>" labels."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    pts = np.array(
+        [[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]], float
+    )
+    cells = [
+        CellBlock("line", np.array([[0, 1], [1, 2]])),
+        CellBlock("quad", np.array([[0, 1, 4, 3], [1, 2, 5, 4]])),
+    ]
+    cell_data = {"gmsh:physical": [np.array([200, 300]), np.array([100, 100])]}
+    mesh = Mesh(pts, cells, cell_data=cell_data)
+
+    filename = tmp_path / "phys.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    # every physical id became a group with the right cells
+    assert set(back.cell_sets) == {"group_100", "group_200", "group_300"}
+    # group_100 -> both quads (block 1); group_200/300 -> one line each (block 0)
+    np.testing.assert_array_equal(back.cell_sets["group_100"][1], [0, 1])
+    np.testing.assert_array_equal(back.cell_sets["group_200"][0], [0])
+    np.testing.assert_array_equal(back.cell_sets["group_300"][0], [1])
+
+
+def test_gmsh_physical_groups_use_field_data_names(tmp_path):
+    """When the .msh had $PhysicalNames, the readable group name comes from
+    field_data ({name: [physical_id, dim]}) instead of the "group_<id>"
+    fallback."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    pts = np.array([[0, 0], [1, 0], [0, 1]], float)
+    cells = [CellBlock("triangle", np.array([[0, 1, 2]]))]
+    mesh = Mesh(
+        pts,
+        cells,
+        cell_data={"gmsh:physical": [np.array([7])]},
+        field_data={"my_surface": np.array([7, 2])},
+    )
+
+    filename = tmp_path / "named.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    assert "my_surface" in back.cell_sets
+    np.testing.assert_array_equal(back.cell_sets["my_surface"][0], [0])
+
+
+def test_gmsh_physical_and_cell_sets_both_preserved(tmp_path):
+    """Gmsh 4.1 can carry BOTH: a named group in cell_sets AND an un-named
+    physical id only in gmsh:physical. Both must survive to MED — the
+    gmsh:physical bridge must not be skipped just because cell_sets is
+    non-empty (and must not duplicate the already-named group)."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    pts = np.array([[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]], float)
+    cells = [CellBlock("triangle", np.array([[0, 1, 3], [1, 2, 4], [2, 5, 4]]))]
+    # cell 0 -> named group "surf" (physical 7); cells 1,2 -> un-named physical 9
+    mesh = Mesh(
+        pts,
+        cells,
+        cell_data={"gmsh:physical": [np.array([7, 9, 9])]},
+        cell_sets={"surf": [np.array([0])]},
+        field_data={"surf": np.array([7, 2])},
+    )
+
+    filename = tmp_path / "mixed.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    # the named group survives, un-named physical 9 becomes group_9,
+    # and "surf" is NOT duplicated as group_7
+    assert "surf" in back.cell_sets
+    assert "group_9" in back.cell_sets
+    assert "group_7" not in back.cell_sets
+    np.testing.assert_array_equal(back.cell_sets["surf"][0], [0])
+    np.testing.assert_array_equal(back.cell_sets["group_9"][0], [1, 2])


### PR DESCRIPTION
## Issue

Converting a Gmsh mesh with physical groups to MED dropped every group. The cause is that meshlane holds groups in two different places depending on the source format:

- `cell_sets` : named sets, used by Abaqus, Ansys `.inp`, FLAC3D, MED, and Gmsh 4.1 with `$PhysicalNames`.
- `cell_data["gmsh:physical"]` : one integer physical id per cell, used by Gmsh 2.2/4.0, MDPA, and un-named Gmsh 4.1 groups.

The MED writer built families only from `cell_sets`. When a mesh carried its groups as `gmsh:physical` (e.g. any Gmsh 2.2 file), `cell_sets` was empty, so no families were written and the groups were lost.
## Fix

In `_ensure_med_families`, the element-family branch now folds **both** sources into a single per-cell group map, then creates one MED family per unique combination of groups:
- named `cell_sets` are processed as before.
- `gmsh:physical` ids are also processed, skipping any id already exposed as a named `cell_set` (avoids a duplicate group). 
- element families keep negative ids and id `0` maps to "no group", per the MED spec.

The two paths are complementary, so a mesh mixing named groups and un-named physical ids (possible in Gmsh 4.1) keeps all of them, and a cell in several groups gets one combined family. Formats that only use `cell_sets` are unchanged.