### PR TITLE
feat(med): MED polyhedron (POE) read/write + fix polygon writing

### DIFF
--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -87,6 +87,21 @@ def _med_cells_for_write(cell_type, data):
     return _reorder_med_cells(cell_type, data)
 
 
+def _med_group_key(cell_type):
+    """Map a meshlane cell type to its MED group bucket. MED has a single group
+    for all polyhedra (POE) and a single group for all linear polygons (POG),
+    whereas meshlane splits them by node count (polyhedron<N>, polygon<N>). Those
+    are bucketed under a common key so they merge into one MED group on write.
+    "polygon2" is the MED quadratic polygon (POG2) and keeps its own bucket."""
+    if cell_type.startswith("polyhedron"):
+        return "polyhedron"
+    if cell_type == "polygon2":
+        return "polygon2"
+    if cell_type.startswith("polygon"):
+        return "polygon"
+    return cell_type
+
+
 numpy_void_str = np.bytes_("")
 
 MED_FLOAT32 = 4
@@ -111,7 +126,8 @@ med_to_geo_type = {
     "HE8": "MED_HEXA8", "H20": "MED_HEXA20", "H27": "MED_HEXA27",
     "PY5": "MED_PYRA5", "P13": "MED_PYRA13",
     "PE6": "MED_PENTA6", "P15": "MED_PENTA15", "PE18": "MED_PENTA18",
-    "POG": "MED_POLYGON", "POG2": "MED_POLYGON2"
+    "POG": "MED_POLYGON", "POG2": "MED_POLYGON2",
+    "POE": "MED_POLYHEDRON",
 }
 med_type_to_entity = {
     "PO1": "MED_NODE_ELEMENT",
@@ -123,6 +139,7 @@ med_type_to_entity = {
     "PY5": "MED_CELL", "P13": "MED_CELL",
     "PE6": "MED_CELL", "P15": "MED_CELL", "PE18": "MED_CELL",
     "POG": "MED_CELL", "POG2": "MED_CELL",
+    "POE": "MED_CELL",
 }
 
 
@@ -363,6 +380,40 @@ def read(filename):
     cell_types = []
     med_cells = mesh["MAI"]
     for med_cell_type, med_cell_type_group in med_cells.items():
+        if med_cell_type == "POE":  # MED_POLYHEDRON: variable faces and nodes
+            nod = med_cell_type_group["NOD"][()] - 1  # flat node ids of every face
+            inn = med_cell_type_group["INN"][()]  # per-face index into NOD
+            ifn = med_cell_type_group["IFN"][()]  # per-polyhedron index into faces
+            fam = (
+                med_cell_type_group["FAM"][()]
+                if "FAM" in med_cell_type_group
+                else None
+            )
+            n_poly = len(ifn) - 1
+            polys = []
+            for p in range(n_poly):
+                faces = [
+                    nod[inn[fidx] - 1 : inn[fidx + 1] - 1]
+                    for fidx in range(ifn[p] - 1, ifn[p + 1] - 1)
+                ]
+                polys.append(faces)
+            # Group by unique node count into polyhedron<N> blocks, matching the
+            # meshlane convention (see openfoam._build_polyhedra).
+            by_n = defaultdict(list)
+            for i, poly in enumerate(polys):
+                n_nodes = len(set().union(*poly)) if poly else 0
+                by_n[n_nodes].append(i)
+            for n_nodes, idxs in by_n.items():
+                block = np.empty(len(idxs), dtype=object)
+                for j, i in enumerate(idxs):
+                    block[j] = [np.asarray(f, dtype=int) for f in polys[i]]
+                cells.append((f"polyhedron{n_nodes}", block))
+                cell_types.append(f"polyhedron{n_nodes}")
+                if fam is not None:
+                    if "cell_tags" not in cell_data:
+                        cell_data["cell_tags"] = []
+                    cell_data["cell_tags"].append(fam[np.array(idxs)])
+            continue
         cell_type = med_to_meshio_type[med_cell_type]
         cell_types.append(cell_type)
         if med_cell_type in ("POG", "POG2"):  # polygonal cells with variable node count
@@ -684,36 +735,92 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
 
     for k, cell_block in enumerate(mesh.cells):
         cell_type = cell_block.type
-        if cell_type not in cells_by_type:
-            cells_by_type[cell_type] = []
-            cell_tags_by_type[cell_type] = []
-        cells_by_type[cell_type].append(cell_block.data)
+        # Variable-size cells share a single MED group: all polyhedron<N> -> POE,
+        # all linear polygon<N> (and generic "polygon") -> POG. "polygon2" is the
+        # MED quadratic polygon (POG2), so it keeps its own bucket. Bucket them
+        # here under a common key; they are merged when written below.
+        key = _med_group_key(cell_type)
+        if key not in cells_by_type:
+            cells_by_type[key] = []
+            cell_tags_by_type[key] = []
+        cells_by_type[key].append(cell_block.data)
         if "cell_tags" in mesh.cell_data:
-            cell_tags_by_type[cell_type].append(mesh.cell_data["cell_tags"][k])
+            cell_tags_by_type[key].append(mesh.cell_data["cell_tags"][k])
     cells_group = time_step.create_group("MAI")
     cells_group.attrs.create("CGT", 1)
     for cell_type, cells_list in cells_by_type.items():
-        med_type = meshio_to_med_type[cell_type]
+        if cell_type == "polyhedron":
+            med_type = "POE"
+        elif cell_type == "polygon":
+            med_type = "POG"
+        elif cell_type == "polygon2":
+            med_type = "POG2"
+        else:
+            med_type = meshio_to_med_type[cell_type]
         med_cells = cells_group.create_group(med_type)
         med_cells.attrs.create("CGT", 1)
         med_cells.attrs.create("CGS", 1)
         med_cells.attrs.create("PFL", np.bytes_(profile))
-        if cell_type in ("polygon", "polygon2"):
-            all_polygons = sum(cells_list, [])
-            all_nodes = np.concatenate([c + 1 for c in all_polygons])
-            lengths = [len(c) for c in all_polygons]
-            inn = np.concatenate([[1], np.cumsum(lengths) + 1])
+        if cell_type == "polyhedron":
+            # MED_POLYHEDRON (POE): three-level, 1-based indexing --
+            #   NOD : flat node ids of every face, all polyhedra concatenated
+            #   INN : per-face offsets into NOD              (len = n_faces + 1)
+            #   IFN : per-polyhedron offsets into the faces  (len = n_poly + 1)
+            # meshlane stores each polyhedron as a list of outward-oriented face
+            # node-arrays, which maps directly onto this.
+            all_polys = [poly for arr in cells_list for poly in arr]
+            nod_parts = []
+            inn = [1]
+            ifn = [1]
+            for poly in all_polys:
+                for face in poly:
+                    face = np.asarray(face, dtype=int)
+                    nod_parts.append(face + 1)
+                    inn.append(inn[-1] + len(face))
+                ifn.append(ifn[-1] + len(poly))
+            all_nodes = (
+                np.concatenate(nod_parts) if nod_parts else np.array([], dtype=int)
+            )
+            inn = np.array(inn, dtype=int)
+            ifn = np.array(ifn, dtype=int)
+            # MED requires NBR on every dataset = that dataset's own length.
             nod = med_cells.create_dataset("NOD", data=all_nodes)
             nod.attrs.create("CGT", 1)
-            nod.attrs.create("NBR", len(all_polygons))
+            nod.attrs.create("NBR", len(all_nodes))
             inn_ds = med_cells.create_dataset("INN", data=inn)
             inn_ds.attrs.create("CGT", 1)
+            inn_ds.attrs.create("NBR", len(inn))
+            ifn_ds = med_cells.create_dataset("IFN", data=ifn)
+            ifn_ds.attrs.create("CGT", 1)
+            ifn_ds.attrs.create("NBR", len(ifn))
+            med_cells.attrs.create("GEO", 500)  # MED_POLYHEDRON geometry type
+            n_merged = len(all_polys)
+        elif cell_type in ("polygon", "polygon2"):
+            # cells_list entries may be 2D arrays (polygon<N>, fixed N per block)
+            # or lists of variable-length arrays (generic "polygon"); normalise to
+            # one flat list of node arrays.
+            all_polygons = [
+                np.asarray(poly) for arr in cells_list for poly in arr
+            ]
+            all_nodes = np.concatenate([c + 1 for c in all_polygons])
+            lengths = [len(c) for c in all_polygons]
+            inn = np.concatenate([[1], np.cumsum(lengths) + 1]).astype(int)
+            # MED requires NBR on every dataset = that dataset's own length.
+            nod = med_cells.create_dataset("NOD", data=all_nodes)
+            nod.attrs.create("CGT", 1)
+            nod.attrs.create("NBR", len(all_nodes))
+            inn_ds = med_cells.create_dataset("INN", data=inn)
+            inn_ds.attrs.create("CGT", 1)
+            inn_ds.attrs.create("NBR", len(inn))
+            med_cells.attrs.create("GEO", 400)  # MED_POLYGON geometry type
             n_merged = len(all_polygons)
         else:
             # Merge cells of the same type
             merged_cells = np.concatenate(cells_list, axis=0)
-            merged_cells = _med_cells_for_write(cell_type, merged_cells)  # meshlane -> MED
-            nod = med_cells.create_dataset("NOD", data=merged_cells.flatten(order="F") + 1)
+            merged_cells = _med_cells_for_write(cell_type, merged_cells)
+            nod = med_cells.create_dataset(
+                "NOD", data=merged_cells.flatten(order="F") + 1
+            )
             nod.attrs.create("CGT", 1)
             nod.attrs.create("NBR", len(merged_cells))
             n_merged = len(merged_cells)

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1468,3 +1468,133 @@ def test_med_multi_3d_orientation_and_roundtrip(tmp_path):
     by_name = dict(zip(names, meshes))
     for name, orig in (("a", m1), ("b", m2)):
         np.testing.assert_array_equal(orig.cells[0].data, by_name[name].cells[0].data)
+
+
+# --- polyhedra (MED_POLYHEDRON / POE) --------------------------------------
+
+# unit cube written as a single polyhedron: 8 nodes, 6 outward-oriented quad faces
+_CUBE_PTS = np.array(
+    [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+     [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1]], float,
+)
+_CUBE_FACES = [[0, 3, 2, 1], [4, 5, 6, 7], [0, 1, 5, 4],
+               [1, 2, 6, 5], [2, 3, 7, 6], [3, 0, 4, 7]]
+
+
+def _polyhedron_block(polys):
+    """polys: list of polyhedra, each a list of face node-lists -> object array."""
+    from meshlane._mesh import CellBlock
+
+    data = np.empty(len(polys), dtype=object)
+    for i, faces in enumerate(polys):
+        data[i] = [np.array(f, dtype=int) for f in faces]
+    return CellBlock("polyhedron8", data)
+
+
+def test_polyhedron_roundtrip(tmp_path):
+    """A polyhedral cell survives write -> MED -> read with faces preserved."""
+    from meshlane._mesh import Mesh
+
+    mesh = Mesh(_CUBE_PTS, [_polyhedron_block([_CUBE_FACES])])
+    filename = tmp_path / "poly.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    assert [c.type for c in back.cells] == ["polyhedron8"]
+    orig = [set(f) for f in _CUBE_FACES]
+    got = [set(f.tolist()) for f in back.cells[0].data[0]]
+    assert orig == got
+
+
+def test_polyhedron_med_layout_matches_medcoupling(tmp_path):
+    """Pin the on-disk MED_POLYHEDRON layout (NOD/INN/IFN, GEO=500) to the values
+    MEDCoupling writes for the same two cubes-as-polyhedra."""
+    from meshlane._mesh import Mesh
+
+    pts = np.vstack([_CUBE_PTS, _CUBE_PTS + [2, 0, 0]])
+    p0 = _CUBE_FACES
+    p1 = [[n + 8 for n in f] for f in _CUBE_FACES]
+    mesh = Mesh(pts, [_polyhedron_block([p0, p1])])
+
+    filename = tmp_path / "poly2.med"
+    meshlane.write(filename, mesh)
+
+    with h5py.File(filename, "r") as f:
+        m = f["ENS_MAA"]["mesh"]
+        if "NOE" not in m:
+            m = m[list(m.keys())[0]]
+        g = m["MAI"]["POE"]
+        nod, inn, ifn = g["NOD"][()], g["INN"][()], g["IFN"][()]
+        geo = g.attrs["GEO"]
+
+    # reference values produced by MEDCoupling's MEDLoader for the same cells
+    ref_ifn = [1, 7, 13]
+    ref_inn = [1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45, 49]
+    ref_nod = [1, 4, 3, 2, 5, 6, 7, 8, 1, 2, 6, 5, 2, 3, 7, 6, 3, 4, 8, 7,
+               4, 1, 5, 8, 9, 12, 11, 10, 13, 14, 15, 16, 9, 10, 14, 13,
+               10, 11, 15, 14, 11, 12, 16, 15, 12, 9, 13, 16]
+    assert geo == 500
+    np.testing.assert_array_equal(ifn, ref_ifn)
+    np.testing.assert_array_equal(inn, ref_inn)
+    np.testing.assert_array_equal(nod, ref_nod)
+
+
+def test_polyhedron_mixed_node_counts_split_on_read(tmp_path):
+    """A POE group with polyhedra of different node counts is read back into
+    separate polyhedron<N> blocks (meshlane convention)."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    # a tetra-as-polyhedron (4 nodes, 4 triangular faces) + a cube (8 nodes)
+    tet_pts = np.array([[5, 0, 0], [6, 0, 0], [5, 1, 0], [5, 0, 1]], float)
+    pts = np.vstack([_CUBE_PTS, tet_pts])
+    tet_faces = [[8, 10, 9], [8, 9, 11], [9, 10, 11], [8, 11, 10]]
+    data = np.empty(2, dtype=object)
+    data[0] = [np.array(f) for f in _CUBE_FACES]
+    data[1] = [np.array(f) for f in tet_faces]
+    mesh = Mesh(pts, [CellBlock("polyhedron8", data)])  # mixed 8- and 4-node
+
+    filename = tmp_path / "mixed.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    assert {c.type for c in back.cells} == {"polyhedron8", "polyhedron4"}
+
+
+def test_polyhedron_groups_roundtrip(tmp_path):
+    """Groups (cell_sets) on polyhedra survive the MED round-trip."""
+    from meshlane._mesh import Mesh
+
+    pts = np.vstack([_CUBE_PTS, _CUBE_PTS + [2, 0, 0]])
+    p1 = [[n + 8 for n in f] for f in _CUBE_FACES]
+    mesh = Mesh(
+        pts,
+        [_polyhedron_block([_CUBE_FACES, p1])],
+        cell_sets={"solid": [np.array([0, 1])]},
+    )
+    filename = tmp_path / "polygrp.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    assert "solid" in back.cell_sets
+    np.testing.assert_array_equal(back.cell_sets["solid"][0], [0, 1])
+
+
+def test_polygonN_fixed_block_written_to_med(tmp_path):
+    """OpenFOAM-style polygon<N> blocks (fixed N, stored as a 2D array) are
+    written to MED's POG group and read back with nodes preserved."""
+    from meshlane._mesh import Mesh, CellBlock
+
+    pts = np.array(
+        [[0, 0, 0], [1, 0, 0], [1.5, 1, 0], [0.5, 1.5, 0], [-0.5, 1, 0]], float
+    )
+    pentagon = np.array([[0, 1, 2, 3, 4]])
+    mesh = Mesh(pts, [CellBlock("polygon5", pentagon)])
+
+    filename = tmp_path / "pent.med"
+    meshlane.write(filename, mesh)
+    back = meshlane.read(filename)
+
+    # POG reads back as a generic "polygon" block; nodes preserved
+    assert len(back.cells) == 1
+    assert back.cells[0].type.startswith("polygon")
+    np.testing.assert_array_equal(np.asarray(back.cells[0].data[0]), [0, 1, 2, 3, 4])


### PR DESCRIPTION
## Issue

Converting an OpenFOAM mesh with polyhedral cells to MED crashed:

    KeyError: 'polyhedron10'

The MED writer had no polyhedron support, and its variable-node polygon path only handled the literal types `polygon`/`polygon2`, not the `polygon<N>` blocks the OpenFOAM reader produces (so `polygon5` also crashed).

## Fix

`src/meshlane/med/_med.py`:

- **Polyhedron write/read (MED_POLYHEDRON, group `POE`, `GEO=500`).** Stored with MED's three-level, 1-based indexing:
  - `NOD` : flat node ids of every face, all polyhedra concatenated
  - `INN` : per-face offsets into `NOD`
  - `IFN` : per-polyhedron offsets into the faces

The reader walks `IFN → INN → NOD` to rebuild each polyhedron, groups them by node count into `polyhedron<N>` blocks (meshlane convention), and preserves families as `cell_sets`.
- **`_med_group_key()`**:  buckets all `polyhedron<N>` into one `POE` group and all linear `polygon<N>` (and generic `polygon`) into one `POG` group, keeping `polygon2` (quadratic) as `POG2` . MED has a single group per variable-size family.
- **Polygon writer fix**: `polygon<N>` blocks are now handled, and every index dataset gets its required `NBR` attribute (= its own length) plus `GEO=400`. Without these attributes the MED library failed to read `INN`. This was a latent bug in the existing polygon writer, and is now solved by this PR.
