### PR TITLE
fix(med): consistent 3D-cell orientation for MED readers

### DIFF
--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -7,6 +7,7 @@ import numpy as np
 import re
 
 from ._med41 import FieldBitmaskWriter
+from . import _orient
 
 from .._common import num_nodes_per_cell, warn
 from .._exceptions import ReadError, WriteError
@@ -783,6 +784,47 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
         cells_by_type[key].append(cell_block.data)
         if "cell_tags" in mesh.cell_data:
             cell_tags_by_type[key].append(mesh.cell_data["cell_tags"][k])
+    # Prepare final MED-order connectivity per bucket
+    # "regular" cells (fixed node count per type: tetra, pyramid, wedge,
+    # hexahedron, ...) get the meshlane->MED node permutation here. 3D cells
+    # then go through a topological orientation pass (see _orient) so every
+    # internal face is shared by its two cells with opposite winding, which MED
+    # readers (code_saturne, Salome, code_aster,...) require.
+    prepared = {}
+    orient_blocks = []   # 3D cells fed to the orientation pass
+    orient_keys = []     # bucket key per orientation block (to map masks back)
+    for cell_type, cells_list in cells_by_type.items():
+        if cell_type == "polyhedron":
+            all_polys = [poly for arr in cells_list for poly in arr]
+            prepared[cell_type] = ("poly", all_polys)
+            orient_blocks.append({"kind": "polyhedron", "faces": all_polys})
+            orient_keys.append(cell_type)
+        elif cell_type in ("polygon", "polygon2"):
+            all_polygons = [np.asarray(p) for arr in cells_list for p in arr]
+            prepared[cell_type] = ("polygon", all_polygons)
+        else:
+            # "regular" = a fixed-shape cell (tetra/pyramid/hexahedron/...)
+            merged = np.concatenate(cells_list, axis=0)
+            merged = _med_cells_for_write(cell_type, merged)  # meshlane -> MED
+            prepared[cell_type] = ("regular", merged)
+            if cell_type in _orient.ORIENTABLE_TYPES:
+                orient_blocks.append(
+                    {"kind": "regular", "type": cell_type, "conn": merged}
+                )
+                orient_keys.append(cell_type)
+
+    if orient_blocks:
+        masks = _orient.consistent_orientation_flips(orient_blocks, mesh.points)
+        if masks is not None:
+            for key, mask in zip(orient_keys, masks):
+                data_kind, data = prepared[key]
+                if data_kind == "regular":
+                    data = _orient.apply_regular_flip(key, data, mask)
+                else:  # polyhedron
+                    data = _orient.apply_polyhedron_flip(data, mask)
+                prepared[key] = (data_kind, data)
+
+    # Write cells
     cells_group = time_step.create_group("MAI")
     cells_group.attrs.create("CGT", 1)
     for cell_type, cells_list in cells_by_type.items():
@@ -798,14 +840,13 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
         med_cells.attrs.create("CGT", 1)
         med_cells.attrs.create("CGS", 1)
         med_cells.attrs.create("PFL", np.bytes_(profile))
+        _, data = prepared[cell_type]
         if cell_type == "polyhedron":
             # MED_POLYHEDRON (POE): three-level, 1-based indexing --
             #   NOD : flat node ids of every face, all polyhedra concatenated
             #   INN : per-face offsets into NOD              (len = n_faces + 1)
             #   IFN : per-polyhedron offsets into the faces  (len = n_poly + 1)
-            # meshlane stores each polyhedron as a list of outward-oriented face
-            # node-arrays, which maps directly onto this.
-            all_polys = [poly for arr in cells_list for poly in arr]
+            all_polys = data
             nod_parts = []
             inn = [1]
             ifn = [1]
@@ -833,12 +874,7 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
             med_cells.attrs.create("GEO", 500)  # MED_POLYHEDRON geometry type
             n_merged = len(all_polys)
         elif cell_type in ("polygon", "polygon2"):
-            # cells_list entries may be 2D arrays (polygon<N>, fixed N per block)
-            # or lists of variable-length arrays (generic "polygon"); normalise to
-            # one flat list of node arrays.
-            all_polygons = [
-                np.asarray(poly) for arr in cells_list for poly in arr
-            ]
+            all_polygons = data
             all_nodes = np.concatenate([c + 1 for c in all_polygons])
             lengths = [len(c) for c in all_polygons]
             inn = np.concatenate([[1], np.cumsum(lengths) + 1]).astype(int)
@@ -852,9 +888,7 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
             med_cells.attrs.create("GEO", 400)  # MED_POLYGON geometry type
             n_merged = len(all_polygons)
         else:
-            # Merge cells of the same type
-            merged_cells = np.concatenate(cells_list, axis=0)
-            merged_cells = _med_cells_for_write(cell_type, merged_cells)
+            merged_cells = data
             nod = med_cells.create_dataset(
                 "NOD", data=merged_cells.flatten(order="F") + 1
             )

--- a/src/meshlane/med/_orient.py
+++ b/src/meshlane/med/_orient.py
@@ -1,0 +1,266 @@
+"""Make 3D cells consistently oriented before writing them to MED.
+
+Many MED tools need two neighbouring cells to list their shared face in
+opposite directions. meshlane's fixed per-type node permutation already
+gets this right for normal cells, but not for a few badly warped cells
+(common in cfMesh / snappyHexMesh meshes). Those few break the mesh
+connectivity and MED tools may reject the mesh with a fatal
+face to cell connectivity error.
+
+This module repairs them: it finds which cells share each face, then flips the
+offending cells so every shared face is listed oppositely by its two cells. It
+works purely on the mesh topology and not on cell volumes, to stay robust to any
+warping. A final per-region volume check fixes the overall sign so no cell ends
+up inside-out.
+
+It handles two kinds of 3D cell: regular cells, with a fixed node count per
+type (tetra 4, pyramid 5,...) stored as a rectangular array; and polyhedra,
+with a variable number of faces and nodes per cell.
+"""
+import numpy as np
+
+# The faces of each cell type, in MED's node order (from MEDCoupling's
+# CellModel). Reversed so every cell type and the polyhedra share one
+# outward-facing convention.
+_RAW_FACES = {
+    "tetra": [[0, 2, 1], [0, 3, 2], [2, 3, 1], [1, 3, 0]],
+    "pyramid": [[0, 3, 2, 1], [0, 4, 3], [3, 4, 2], [2, 4, 1], [1, 4, 0]],
+    "wedge": [[0, 2, 1], [3, 4, 5], [0, 3, 5, 2], [2, 5, 4, 1], [1, 4, 3, 0]],
+    "hexahedron": [[0, 3, 2, 1], [4, 5, 6, 7], [0, 4, 7, 3],
+                   [3, 7, 6, 2], [2, 6, 5, 1], [1, 5, 4, 0]],
+}
+_FACES = {t: [f[::-1] for f in fs] for t, fs in _RAW_FACES.items()}
+
+# orientation-reversing node permutations (self-inverse) per MED cell type
+_FLIP_PERM = {
+    "tetra": [0, 2, 1, 3],
+    "pyramid": [0, 3, 2, 1, 4],
+    "wedge": [0, 2, 1, 3, 5, 4],
+    "hexahedron": [0, 3, 2, 1, 4, 7, 6, 5],
+}
+
+ORIENTABLE_TYPES = set(_FACES)
+
+
+def _chirality(ordered):
+    """Return a 0/1 'winding tag' for each face, computed from its node order
+    alone. Two cells share a face using the same node ids: if they list them the
+    same way round the tags match (windings agree, inconsistent for MED); if
+    opposite ways the tags differ (consistent)."""
+    nf, k = ordered.shape
+    idx = np.arange(nf)
+    mn = np.argmin(ordered, axis=1)
+    nxt = ordered[idx, (mn + 1) % k]
+    prv = ordered[idx, (mn - 1) % k]
+    return (nxt < prv).astype(np.int8)
+
+
+def _cell_faces(cell_type, conn):
+    """Yield (size, ordered_faces[n,size]) for a regular cell block."""
+    for face in _FACES[cell_type]:
+        yield len(face), conn[:, face]
+
+
+def _signed_volume(cell_type, conn, points):
+    """Signed volume of each cell, computed from its faces. Positive when the
+    cell is correctly oriented, negative when inside-out (only the sign is
+    used)."""
+    V = np.zeros(len(conn))
+    for face in _FACES[cell_type]:
+        fp = points[conn[:, face]]
+        c = fp.mean(axis=1)
+        k = len(face)
+        for i in range(k):
+            V += np.einsum("ij,ij->i", c,
+                           np.cross(fp[:, i], fp[:, (i + 1) % k])) / 6.0
+    return V
+
+
+def _uf_find(parent, rel, x):
+    """Union-find 'find' with path compression and parity accumulation.
+    Returns (root, parity of x relative to root). Mutates parent/rel in place."""
+    root = x
+    p = 0
+    while parent[root] != root:
+        p ^= rel[root]
+        root = parent[root]
+    cur = x
+    pc = 0
+    while parent[cur] != root:
+        nxt = parent[cur]
+        nb = rel[cur]
+        parent[cur] = root
+        rel[cur] = pc ^ p
+        pc ^= nb
+        cur = nxt
+    return root, p
+
+
+def _solve_parity(n, A, B, par):
+    """Union-find with parity. Returns (flip_bit[n], roots[n], n_nonorientable).
+    flip_bit is each cell's orientation relative to its component's root."""
+    parent = list(range(n))
+    rank = [0] * n
+    rel = [0] * n  # parity relative to parent
+
+    violations = 0
+    for a, b, pab in zip(A.tolist(), B.tolist(), par.tolist()):
+        ra, pa = _uf_find(parent, rel, a)
+        rb, pb = _uf_find(parent, rel, b)
+        want = pab ^ pa ^ pb
+        if ra == rb:
+            if (pa ^ pb) != pab:
+                violations += 1
+            continue
+        if rank[ra] < rank[rb]:
+            ra, rb = rb, ra
+        parent[rb] = ra
+        rel[rb] = want
+        if rank[ra] == rank[rb]:
+            rank[ra] += 1
+
+    flip = np.empty(n, dtype=np.int8)
+    roots = np.empty(n, dtype=np.int64)
+    for x in range(n):
+        r, p = _uf_find(parent, rel, x)
+        flip[x] = p
+        roots[x] = r
+    return flip, roots, violations
+
+
+def _bucket_face(by_size, size, ordered, cids):
+    """Append a face (ordered node array) and its owning cell ids into the
+    per-size accumulator ``by_size`` (size -> ([ordered, ...], [cids, ...]))."""
+    o, c = by_size.setdefault(size, ([], []))
+    o.append(np.asarray(ordered, dtype=np.int64))
+    c.append(cids)
+
+
+def consistent_orientation_flips(blocks, points):
+    """Compute per-block boolean flip masks that make 3D-cell orientation
+    globally consistent for MED.
+
+    blocks: list of dicts, in the order cells are laid out, each either
+        {"kind": "regular", "type": <med cell type>, "conn": (n,k) int array}
+        {"kind": "polyhedron", "faces": [ [face_node_array, ...], ... ]}
+      All node ids are 0-based, in the final MED node ordering.
+    points: (n_points, 3) float array.
+
+    Returns a list (aligned with blocks) of boolean masks (True = flip that
+    cell), or None if there is nothing to do or the mesh is already consistent.
+    """
+    starts = []
+    counts = []
+    gid = 0
+    for blk in blocks:
+        starts.append(gid)
+        if blk["kind"] == "regular":
+            c = len(blk["conn"])
+        else:
+            c = len(blk["faces"])
+        counts.append(c)
+        gid += c
+    n_cells = gid
+    if n_cells == 0:
+        return None
+
+    # enumerate faces grouped by size -> ordered arrays + owning cell id
+    by_size = {}
+    for blk, start in zip(blocks, starts):
+        if blk["kind"] == "regular":
+            conn = blk["conn"]
+            ids = np.arange(start, start + len(conn), dtype=np.int64)
+            for size, ofaces in _cell_faces(blk["type"], conn):
+                _bucket_face(by_size, size, ofaces, ids)
+        else:  # polyhedron: use its stored outward faces
+            for j, faces in enumerate(blk["faces"]):
+                cid = start + j
+                for face in faces:
+                    face = np.asarray(face, dtype=np.int64)
+                    _bucket_face(by_size, len(face), face[None, :],
+                                 np.array([cid], np.int64))
+
+    # build shared-face parity constraints
+    eA, eB, eP = [], [], []
+    for size, (olist, clist) in by_size.items():
+        ordered = np.concatenate(olist, 0)
+        cids = np.concatenate(clist)
+        key = np.sort(ordered, axis=1)
+        order = np.lexsort(key.T[::-1])
+        ks = key[order]
+        cs = cids[order]
+        ch = _chirality(ordered)[order]
+        same = np.all(ks[1:] == ks[:-1], axis=1)
+        pair = np.where(same)[0]
+        if len(pair) == 0:
+            continue
+        eA.append(cs[pair])
+        eB.append(cs[pair + 1])
+        eP.append((ch[pair] == ch[pair + 1]).astype(np.int8))  # same wind -> 1
+    if not eA:
+        return None
+    A = np.concatenate(eA)
+    B = np.concatenate(eB)
+    par = np.concatenate(eP)
+
+    if int(par.sum()) == 0:
+        return None  # already consistent, skip the union-find entirely
+
+    flip, roots, _ = _solve_parity(n_cells, A, B, par)
+
+    # A whole region can still come out inside-out. For each region, flip it if
+    # most of its cells have negative volume.
+    signed = np.zeros(n_cells)
+    have_vol = np.zeros(n_cells, dtype=bool)
+    for blk, start in zip(blocks, starts):
+        if blk["kind"] == "regular":
+            conn = blk["conn"]
+            fp = _FLIP_PERM[blk["type"]]
+            end = start + len(conn)
+            f = flip[start:end].astype(bool)
+            oriented = conn.copy()
+            oriented[f] = conn[f][:, fp]
+            signed[start:end] = _signed_volume(blk["type"], oriented, points)
+            have_vol[start:end] = True
+
+    order = np.argsort(roots, kind="stable")
+    r_sorted = roots[order]
+    bounds = np.flatnonzero(np.r_[True, r_sorted[1:] != r_sorted[:-1], True])
+    comp_flip_root = {}
+    votes = np.where(have_vol, np.sign(signed), 0.0)
+    for i in range(len(bounds) - 1):
+        seg = order[bounds[i]:bounds[i + 1]]
+        root = roots[seg[0]]
+        if votes[seg].sum() < 0:  # component mostly inside-out -> flip it
+            comp_flip_root[root] = 1
+    if comp_flip_root:
+        extra = np.array([comp_flip_root.get(r, 0) for r in roots], dtype=np.int8)
+        flip = flip ^ extra
+
+    masks = []
+    for blk, start, cnt in zip(blocks, starts, counts):
+        masks.append(flip[start:start + cnt].astype(bool))
+    return masks
+
+
+def apply_regular_flip(cell_type, conn, mask):
+    """Return conn with flipped rows reversed by the type's node permutation."""
+    if mask is None or not mask.any():
+        return conn
+    out = conn.copy()
+    out[mask] = conn[mask][:, _FLIP_PERM[cell_type]]
+    return out
+
+
+def apply_polyhedron_flip(faces_list, mask):
+    """Return polyhedra with each flipped cell's faces reversed (winding
+    flipped) so its outward normals invert consistently."""
+    if mask is None or not mask.any():
+        return faces_list
+    out = []
+    for poly, fl in zip(faces_list, mask):
+        if fl:
+            out.append([np.asarray(f)[::-1] for f in poly])
+        else:
+            out.append(poly)
+    return out

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1682,3 +1682,62 @@ def test_polygonN_fixed_block_written_to_med(tmp_path):
     assert len(back.cells) == 1
     assert back.cells[0].type.startswith("polygon")
     np.testing.assert_array_equal(np.asarray(back.cells[0].data[0]), [0, 1, 2, 3, 4])
+
+
+# --- topological 3D-cell orientation for MED (code_saturne consistency) -----
+
+# two hexes sharing the plane x=1, both valid VTK order
+_TWOHEX_PTS = np.array(
+    [[0, 0, 0], [1, 0, 0], [2, 0, 0],
+     [0, 1, 0], [1, 1, 0], [2, 1, 0],
+     [0, 0, 1], [1, 0, 1], [2, 0, 1],
+     [0, 1, 1], [1, 1, 1], [2, 1, 1]], float,
+)
+_TWOHEX = np.array([[0, 1, 4, 3, 6, 7, 10, 9],
+                    [1, 2, 5, 4, 7, 8, 11, 10]])
+_HEX_FLIP = [0, 3, 2, 1, 4, 7, 6, 5]
+
+
+def test_orient_flips_inconsistent_cell():
+    """The orientation pass flips nothing on a consistent mesh, and flips
+    exactly one cell to repair a deliberately inverted neighbour."""
+    from meshlane.med import _orient
+
+    consistent = [{"kind": "regular", "type": "hexahedron",
+                   "conn": _TWOHEX.copy()}]
+    assert _orient.consistent_orientation_flips(consistent, _TWOHEX_PTS) is None
+
+    bad = _TWOHEX.copy()
+    bad[1] = bad[1][_HEX_FLIP]  # invert one hex -> inconsistent shared face
+    masks = _orient.consistent_orientation_flips(
+        [{"kind": "regular", "type": "hexahedron", "conn": bad}], _TWOHEX_PTS
+    )
+    assert masks is not None
+    assert int(masks[0].sum()) == 1
+
+
+def test_med_writer_produces_consistent_orientation(tmp_path):
+    """A mesh with an inverted 3D cell is written to MED with globally
+    consistent face orientation (every internal face shared with opposite
+    winding), so MED readers like code_saturne accept it."""
+    from meshlane._mesh import Mesh, CellBlock
+    from meshlane.med import _orient
+
+    conn = _TWOHEX.copy()
+    conn[1] = conn[1][_HEX_FLIP]  # inconsistent input
+    mesh = Mesh(_TWOHEX_PTS, [CellBlock("hexahedron", conn)])
+
+    filename = tmp_path / "orient.med"
+    meshlane.write(filename, mesh)
+
+    # read the on-disk MED-order hexes and assert they are now consistent
+    with h5py.File(filename, "r") as f:
+        m = f["ENS_MAA"]["mesh"]
+        if "NOE" not in m:
+            m = m[list(m.keys())[0]]
+        he8 = m["MAI"]["HE8"]["NOD"]
+        nbr = he8.attrs["NBR"]
+        dconn = he8[()].reshape(nbr, -1, order="F") - 1
+    blocks = [{"kind": "regular", "type": "hexahedron", "conn": dconn}]
+    # already consistent on disk -> the pass finds nothing to fix
+    assert _orient.consistent_orientation_flips(blocks, _TWOHEX_PTS) is None


### PR DESCRIPTION
## Issue

An OpenFOAM mesh converted to MED used in code_saturne had the following preprocessor error:

    There are N faces of which one same side belongs to at least 2 cells
    --> bad connectivity.
    The mesh has face -> cell connectivity errors. We can go no further.

MED readers build a descending (face to cell) connectivity and require every internal face to be shared by its two cells with opposite winding. meshlane's per-type node permutation gives the right winding for well-formed cells, but it cannot orient a warped cell (one whose corner orientation disagrees with its true volume). Such cells can break the connectivity and make the software reject the mesh. 

## Fix

A new numpy module `src/meshlane/med/_orient.py` is introduced. Before writing 3D cells it makes their orientation globally consistent topologically (not with a volume heuristic, so it is robust to any warping):

1. Enumerate every 3D cell's faces (regular fixed-shape types via MED face tables, polyhedra via their stored faces).
2. Match shared faces and require each internal face to be shared with opposite winding.
3. Solve with union-find with parity, giving each cell a flip bit that makes every internal face consistent. 
4. Anchor each connected component's global sign by the majority true volume of its cells, so nothing ends up inside-out.

The MED write path runs 3D cells through this pass and reverses the flagged cells before writing. The pass is skipped when the mesh is already consistent, so MED to MED round-trips and well-formed meshes are untouched.
