### PR TITLE
feat(cli): show read/write progress in convert

### DIFF
--- a/src/meshlane/_cli/_convert.py
+++ b/src/meshlane/_cli/_convert.py
@@ -50,6 +50,7 @@ def add_args(parser):
 
 def convert(args):
     # read mesh data
+    print(f"Reading '{args.infile}' (large meshes may take a while)...", flush=True)
     mesh = read(args.infile, file_format=args.input_format)
 
     # Some converters (like VTK) require `points` to be contiguous.
@@ -72,4 +73,6 @@ def convert(args):
     if args.ascii:
         kwargs["binary"] = False
 
+    print(f"Writing '{args.outfile}'...", flush=True)
     write(args.outfile, mesh, **kwargs)
+    print("Done.")


### PR DESCRIPTION


`meshlane convert` gives no output while it runs. On large meshes the read and write can each take minutes (e.g. a 3.3M-cell mes case can take 3-4 min), so the CLI looks frozen and the user can't tell if anything is happening.

`src/meshlane/_cli/_convert.py`: print a short status line before each slow phase (read, write) and a final "Done.".  Each message uses `flush=True` so it appears before the long blocking operation, not after.

