### PR TITLE
fix(ansysInp): read COMPACT EBLOCK and 1-integer NBLOCK formats

### DIFF
--- a/src/meshlane/ansysInp/_ansysInp.py
+++ b/src/meshlane/ansysInp/_ansysInp.py
@@ -52,6 +52,12 @@ def _int_width(fmt):
     return int(m.group(2)) if m else 0
 
 
+def _int_count(fmt):
+    # number of integer fields in a block format, e.g. 3 in "(3i9,6e21...)"
+    m = re.search(r"(\d+)i(\d+)", fmt, re.IGNORECASE)
+    return int(m.group(1)) if m else 1
+
+
 def _real_width(fmt):
     m = re.search(r"(\d+)[eg](\d+)\.", fmt, re.IGNORECASE)
     return int(m.group(2)) if m else 0
@@ -116,10 +122,23 @@ def _read_lines(lines):
     etype_lib, node_id, coords, elements = {}, [], [], []
     node_comps, elem_comps = {}, {}
     saw_block = False
+    active_type = None
     i, n = 0, len(lines)
     while i < n:
         line = lines[i].strip()
         up = line.upper()
+
+        # Track the active element type. In COMPACT EBLOCKs the type is not on each
+        # element line, it is whatever the last TYPE command set. TYPE may share a
+        # line with other commands, e.g. "MAT,1 $ TYPE,1 $ REAL,1 $ SECNUM,1".
+        if "TYPE," in up:
+            for part in up.split("$"):
+                part = part.strip()
+                if part.startswith("TYPE,"):
+                    try:
+                        active_type = int(part.split(",")[1].split("!")[0])
+                    except (ValueError, IndexError):
+                        pass
 
         if up.startswith("ET,"):
             p = line.split(",")
@@ -150,6 +169,7 @@ def _read_lines(lines):
             saw_block = True
             iw = _int_width(lines[i + 1]) or 9
             rw = _real_width(lines[i + 1]) or 20
+            n_int = _int_count(lines[i + 1]) or 1
             i += 2
             while i < n:
                 l = lines[i]
@@ -168,11 +188,47 @@ def _read_lines(lines):
                     i += 1
                     break
 
-                rs = (_slice_reals(l[3 * iw:], rw) + [0.0, 0.0, 0.0])[:3]
+                rs = (_slice_reals(l[n_int * iw:], rw) + [0.0, 0.0, 0.0])[:3]
                 node_id.append(nid)
                 coords.append(rs)
                 i += 1
+        elif up.startswith("EBLOCK") and "COMPACT" in up:
+            # COMPACT EBLOCK: rows are "elem_id node1 ... nodeN" (no per-element
+            # header) and the type is the active TYPE. Read the whole block as one
+            # integer stream and split it by the element count from the header.
+            # This also handles elements that wrap across lines (e.g. a 20-node hex).
+            saw_block = True
+            parts = [p.strip() for p in up.split(",")]
+            try:
+                num_elem = int(parts[4].split("!")[0])
+            except (IndexError, ValueError):
+                num_elem = 0
+            iw = _int_width(lines[i + 1]) or 9
+            i += 2
+            flat = []
+            while i < n:
+                l = lines[i]
+                if l.strip().startswith("-1"):
+                    i += 1
+                    break
+                if not _is_data_line(l):
+                    break
+                flat += _slice_ints(l, iw)
+                i += 1
+            if num_elem and flat and len(flat) % num_elem == 0:
+                rec = len(flat) // num_elem
+                for k in range(num_elem):
+                    chunk = flat[k * rec:(k + 1) * rec]
+                    elements.append((active_type, chunk[0], chunk[1:]))
+            elif flat:
+                raise ReadError(
+                    "COMPACT EBLOCK: cannot determine node count "
+                    f"({len(flat)} integers for {num_elem} elements)."
+                )
         elif up.startswith("EBLOCK"):
+            # SOLID EBLOCK: each element line is a fixed header
+            # (material, type, ..., node count, elem_id) followed by the node
+            # numbers, which continue on the next line if they don't all fit.
             saw_block = True
             iw = _int_width(lines[i + 1]) or 9
             i += 2

--- a/tests/test_ansysInp.py
+++ b/tests/test_ansysInp.py
@@ -457,3 +457,56 @@ class TestCMBlockEdgeCases:
         from meshlane._exceptions import ReadError
         with pytest.raises(ReadError, match="range marker"):
             _read_from_str(BAD_CMBLOCK_INP)
+
+
+# Tests: 1-integer NBLOCK header + COMPACT EBLOCK (single- and multi-line)
+def _fmt_1i9_nblock(coords):
+    lines = [f"nblock,3,,{len(coords)}", "(1i9,3e20.9e3)"]
+    for i, (x, y, z) in enumerate(coords, 1):
+        lines.append(f"{i:9d}{x:20.9E}{y:20.9E}{z:20.9E}")
+    lines.append("N,R5.3,LOC,      -1,")
+    return "\n".join(lines)
+
+
+def _fmt_compact_eblock(elems):
+    lines = [f"eblock,11,COMPACT,,{len(elems)}", "(11i9)"]
+    for eid, nodes in enumerate(elems, 1):
+        vals = [eid] + list(nodes)
+        for k in range(0, len(vals), 11):  # 11 fields per line, wrap
+            lines.append("".join(f"{v:9d}" for v in vals[k:k + 11]))
+    lines.append("       -1")
+    return "\n".join(lines)
+
+
+class TestCompactEblock:
+    def test_1i9_nblock_and_compact_hex(self):
+        # unit cube, SOLID185 (linear hex), COMPACT eblock, 1-integer NBLOCK
+        coords = [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+                  (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)]
+        inp = (
+            "/PREP7\net,1,185\nMAT,1 $ TYPE,1 $ REAL,1\n"
+            + _fmt_1i9_nblock(coords) + "\n"
+            + _fmt_compact_eblock([list(range(1, 9))])
+        )
+        mesh = _read_from_str(inp)
+        assert len(mesh.points) == 8
+        # coordinates parsed correctly from the 1-integer NBLOCK
+        assert np.allclose(mesh.points[0], [0.0, 0.0, 0.0])
+        assert np.allclose(mesh.points[6], [1.0, 1.0, 1.0])
+        assert len(mesh.cells) == 1
+        assert mesh.cells[0].type == "hexahedron"
+        assert mesh.cells[0].data.shape == (1, 8)
+
+    def test_compact_multiline_hex20(self):
+        # SOLID186 (hex20): 20 nodes span two lines in COMPACT (11i9)
+        coords = [(float(i), 0.0, 0.0) for i in range(20)]
+        inp = (
+            "/PREP7\net,1,186\nMAT,1 $ TYPE,1 $ REAL,1\n"
+            + _fmt_1i9_nblock(coords) + "\n"
+            + _fmt_compact_eblock([list(range(1, 21))])
+        )
+        mesh = _read_from_str(inp)
+        assert mesh.cells[0].type == "hexahedron20"
+        assert mesh.cells[0].data.shape == (1, 20)
+        # elem_id stripped; 20 nodes in order (0-based)
+        assert mesh.cells[0].data[0].tolist() == list(range(20))


### PR DESCRIPTION
## Problem

Ansys `.inp` exports use two block formats the reader crashed on.

A node block with a single id column (`(1i9,3e20.9e3)`):

    ValueError: could not convert string to float: '00     1.007925656E+'

and a COMPACT element block (`eblock,11,COMPACT,,68886`):

    Unsupported type: etype 1 with 9 nodes.

The reader assumed 3 integer columns in every `NBLOCK` (so it sliced the coordinates from the wrong position), and only understood the SOLID `EBLOCK` layout, so COMPACT rows were misread and elements spanning several lines (e.g. a 20-node hex) became bogus cells.

## Fix

`src/meshlane/ansysInp/_ansysInp.py`:

- **`NBLOCK`**: read the integer-field count from the format line (`_int_count()`) and start the coordinates at `n_int * iw` instead of a hardcoded `3 * iw`, so `(1i9,...)` node blocks parse.
- **COMPACT `EBLOCK`**: each row is `elem_id node1 ... nodeN` with no per-element header. Read the whole block as one integer stream and split it by the element count from the header; take the element type from the active `TYPE` command (tracked from `TYPE,n`, including compound `MAT,1 $ TYPE,1 $ ...` lines). This also handles elements that wrap across lines.
- The SOLID `EBLOCK` path is unchanged.

