### PR TITLE
feat(mesh/cli): opt-in removal of duplicate (coincident) cells

### DIFF
--- a/src/meshlane/_cli/_convert.py
+++ b/src/meshlane/_cli/_convert.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .._common import warn
 from .._helpers import _writer_map, read, reader_map, write
 
 
@@ -46,6 +47,11 @@ def add_args(parser):
         action="store_true",
         help="if possible, convert integer data to sets (useful if the output type does not support integer data)",
     )
+    parser.add_argument(
+        "--remove-duplicates",
+        action="store_true",
+        help="remove duplicate cells (cells sharing the same node set); off by default",
+    )
 
 
 def convert(args):
@@ -55,6 +61,29 @@ def convert(args):
 
     # Some converters (like VTK) require `points` to be contiguous.
     mesh.points = np.ascontiguousarray(mesh.points)
+
+    # Duplicate (coincident) cells: remove on request, otherwise just warn.
+    if args.remove_duplicates:
+        n_dup = mesh.remove_duplicate_cells()
+        if n_dup:
+            print(f"Removed {n_dup} duplicate cell(s) with identical node sets.")
+    else:
+        seen = set()
+        n_dup = 0
+        for cell_block in mesh.cells:
+            for row in cell_block.data:
+                key = (cell_block.type, frozenset(int(x) for x in row))
+                if key in seen:
+                    n_dup += 1
+                else:
+                    seen.add(key)
+        if n_dup:
+            warn(
+                f"{n_dup} duplicate cell(s) with identical node sets were detected. "
+                "Coincident cells may cause connectivity errors in some solvers. "
+                "To remove them, rerun the conversion with the --remove-duplicates "
+                "option."
+            )
 
     if args.sets_to_int_data:
         mesh.point_sets_to_data()

--- a/src/meshlane/_mesh.py
+++ b/src/meshlane/_mesh.py
@@ -272,6 +272,46 @@ class Mesh:
             [d for c, d in zip(self.cells, self.cell_data[name]) if c.type == cell_type]
         )
 
+    def remove_duplicate_cells(self):
+        """Remove cells that duplicate another cell of the same type (identical
+        node set, order-independent), keeping the first occurrence.
+
+        ``cell_data`` and ``cell_sets`` are remapped onto the surviving cells.
+        Returns the number of cells removed.
+
+        Coincident cells occupy the same space and can cause connectivity errors
+        in downstream solvers (e.g. code_saturne). This is opt-in: meshlane keeps
+        the mesh faithful by default.
+        """
+        seen = set()
+        keeps = []
+        n_removed = 0
+        for cell_block in self.cells:
+            keep = np.ones(len(cell_block.data), dtype=bool)
+            for j, row in enumerate(cell_block.data):
+                key = (cell_block.type, frozenset(int(x) for x in row))
+                if key in seen:
+                    keep[j] = False
+                else:
+                    seen.add(key)
+            keeps.append(keep)
+            n_removed += int((~keep).sum())
+        if n_removed == 0:
+            return 0
+        for cell_block, keep in zip(self.cells, keeps):
+            cell_block.data = cell_block.data[keep]
+        for name, value_list in self.cell_data.items():
+            self.cell_data[name] = [v[k] for v, k in zip(value_list, keeps)]
+        for name, member_list in self.cell_sets.items():
+            new_members = []
+            for members, keep in zip(member_list, keeps):
+                new_index = np.cumsum(keep) - 1  # old local index -> new index
+                members = np.asarray(members, dtype=int)
+                members = members[keep[members]]  # drop members that were removed
+                new_members.append(new_index[members])
+            self.cell_sets[name] = new_members
+        return n_removed
+
     @property
     def cells_dict(self):
         cells_dict = {}

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -106,3 +106,29 @@ def test_copy():
 
     assert np.all(mesh.points == mesh2.points)
     assert not np.may_share_memory(mesh.points, mesh2.points)
+
+
+def test_remove_duplicate_cells():
+    # cell 2 duplicates cell 0 (same node set, different node order)
+    tri = np.array([[0, 1, 2], [1, 2, 3], [0, 2, 1]])
+    pts = np.random.rand(4, 3)
+    mesh = meshlane.Mesh(
+        pts,
+        [("triangle", tri)],
+        cell_data={"val": [np.array([10, 20, 30])]},
+        cell_sets={"A": [np.array([0, 2])], "B": [np.array([1])]},
+    )
+    n = mesh.remove_duplicate_cells()
+    assert n == 1
+    assert_equal(mesh.cells[0].data, np.array([[0, 1, 2], [1, 2, 3]]))
+    # cell_data of the dropped cell is removed
+    assert_equal(mesh.cell_data["val"][0], np.array([10, 20]))
+    # set A loses the dropped duplicate (kept cell 0 -> new index 0)
+    assert_equal(mesh.cell_sets["A"][0], np.array([0]))
+    # set B: cell 1 -> new index 1
+    assert_equal(mesh.cell_sets["B"][0], np.array([1]))
+
+
+def test_remove_duplicate_cells_none():
+    mesh = copy.deepcopy(helpers.tri_mesh)
+    assert mesh.remove_duplicate_cells() == 0


### PR DESCRIPTION
## Problem

Some meshes may  contain duplicated elements: two cells with the same node set, occupying the same space. Some solvers reject that, e.g. code_saturne fails with:

    There are 524 faces of which one same side belongs to at least 2 cells
    --> bad connectivity.

Others tolerate it (code_aster shows a warning), and the duplicates may be legitimate in some FEA meshes (contact element pairs), so meshlane should not silently delete cells.

## Fix

- **`Mesh.remove_duplicate_cells()`** (`src/meshlane/_mesh.py`): drops cells whose  `(type, node set)` was already seen, keeping the first; remaps `cell_data` and `cell_sets` onto the survivors; returns the count.
- **`meshlane convert --remove-duplicates`** (`src/meshlane/_cli/_convert.py`):
  - default: keep all cells but **warn** if duplicates are detected (with a hint to re-run using the flag);
  - `--remove-duplicates`: remove them and report how many.
