### PR TITLE
fix: duplicate-cell detection must skip polyhedron/polygon cells

### DIFF
--- a/src/meshlane/_cli/_convert.py
+++ b/src/meshlane/_cli/_convert.py
@@ -68,15 +68,7 @@ def convert(args):
         if n_dup:
             print(f"Removed {n_dup} duplicate cell(s) with identical node sets.")
     else:
-        seen = set()
-        n_dup = 0
-        for cell_block in mesh.cells:
-            for row in cell_block.data:
-                key = (cell_block.type, frozenset(int(x) for x in row))
-                if key in seen:
-                    n_dup += 1
-                else:
-                    seen.add(key)
+        n_dup = mesh.remove_duplicate_cells(dry_run=True)
         if n_dup:
             warn(
                 f"{n_dup} duplicate cell(s) with identical node sets were detected. "

--- a/src/meshlane/_mesh.py
+++ b/src/meshlane/_mesh.py
@@ -272,12 +272,16 @@ class Mesh:
             [d for c, d in zip(self.cells, self.cell_data[name]) if c.type == cell_type]
         )
 
-    def remove_duplicate_cells(self):
+    def remove_duplicate_cells(self, dry_run=False):
         """Remove cells that duplicate another cell of the same type (identical
-        node set, order-independent), keeping the first occurrence.
+        node set, order-independent), keeping the first occurrence. Returns the
+        number removed; with ``dry_run=True`` returns the number that *would* be
+        removed without modifying the mesh.
 
         ``cell_data`` and ``cell_sets`` are remapped onto the surviving cells.
-        Returns the number of cells removed.
+        Only fixed-shape ("regular") cell types are considered; ``polyhedron``
+        and ``polygon`` blocks (whose rows are not flat node lists) are left
+        untouched.
 
         Coincident cells occupy the same space and can cause connectivity errors
         in downstream solvers (e.g. code_saturne). This is opt-in: meshlane keeps
@@ -288,20 +292,24 @@ class Mesh:
         n_removed = 0
         for cell_block in self.cells:
             keep = np.ones(len(cell_block.data), dtype=bool)
-            for j, row in enumerate(cell_block.data):
-                key = (cell_block.type, frozenset(int(x) for x in row))
-                if key in seen:
-                    keep[j] = False
-                else:
-                    seen.add(key)
+            if not cell_block.type.startswith(("polyhedron", "polygon")):
+                for j, row in enumerate(cell_block.data):
+                    key = (cell_block.type, frozenset(int(x) for x in row))
+                    if key in seen:
+                        keep[j] = False
+                    else:
+                        seen.add(key)
             keeps.append(keep)
             n_removed += int((~keep).sum())
-        if n_removed == 0:
-            return 0
+        if dry_run or n_removed == 0:
+            return n_removed
         for cell_block, keep in zip(self.cells, keeps):
-            cell_block.data = cell_block.data[keep]
+            if not keep.all():
+                cell_block.data = cell_block.data[keep]
         for name, value_list in self.cell_data.items():
-            self.cell_data[name] = [v[k] for v, k in zip(value_list, keeps)]
+            self.cell_data[name] = [
+                v if v is None else v[k] for v, k in zip(value_list, keeps)
+            ]
         for name, member_list in self.cell_sets.items():
             new_members = []
             for members, keep in zip(member_list, keeps):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -132,3 +132,22 @@ def test_remove_duplicate_cells():
 def test_remove_duplicate_cells_none():
     mesh = copy.deepcopy(helpers.tri_mesh)
     assert mesh.remove_duplicate_cells() == 0
+
+
+def test_remove_duplicate_cells_skips_polyhedron():
+    # polyhedron rows are lists of face arrays, not flat node lists: dedup must
+    # skip them (no crash) while still de-duplicating regular blocks.
+    poly = np.empty(1, dtype=object)
+    poly[0] = [np.array([0, 1, 2]), np.array([0, 1, 3]),
+               np.array([1, 2, 3]), np.array([2, 0, 3])]
+    pts = np.random.rand(4, 3)
+    mesh = meshlane.Mesh(
+        pts,
+        [("polyhedron4", poly),
+         ("triangle", np.array([[0, 1, 2], [0, 2, 1]]))],  # cell 1 dups cell 0
+    )
+    assert mesh.remove_duplicate_cells(dry_run=True) == 1
+    n = mesh.remove_duplicate_cells()
+    assert n == 1
+    assert len(mesh.cells[0].data) == 1  # polyhedron untouched
+    assert len(mesh.cells[1].data) == 1  # duplicate triangle removed


### PR DESCRIPTION
## Issue

Regression from #17: `meshlane convert` runs duplicate-cell detection by default, and it crashed on meshes with polyhedron cells :

    key = (cell_block.type, frozenset(int(x) for x in row))
    TypeError: only length-1 arrays can be converted to Python scalars

A polyhedron cell's row is a list of face arrays, not flat node ids. This broke a foam to med conversion  which previously worked.

## Fix

The check assumed each cell row is a flat list of node ids; a polyhedron row is a list of face arrays, so `int(x)` hit an array. `convert` runs the check by default (to warn), so it broke `foam -> med` without the flag.

- `Mesh.remove_duplicate_cells()`: only check regular cell types; leave `polyhedron`/`polygon` blocks untouched (not counted, not removed). Add a `dry_run` argument that returns the count without modifying the mesh.
- `convert`: the default path (the one that only warns) had its own duplicate-counting loop, separate from the method, and that loop is what crashed on polyhedra. It has been removed; the default path now calls `remove_duplicate_cells(dry_run=True)` to get the count, so the same poly-safe code is used whether we are warning or removing. The default still only warns.

