### PR TITLE
Closes issue #27

### DIFF
--- a/src/meshlane/gmsh/common.py
+++ b/src/meshlane/gmsh/common.py
@@ -161,56 +161,48 @@ _gmsh_to_meshio_type = {
 _meshio_to_gmsh_type = {v: k for k, v in _gmsh_to_meshio_type.items()}
 
 
+# Gmsh cells are mostly ordered like VTK, with a few exceptions. Only this direction is
+# written out; the reverse is derived below, so the two cannot fall out of step.
+_gmsh_to_meshio = {
+    # fmt: off
+    "tetra10": [0, 1, 2, 3, 4, 5, 6, 7, 9, 8],
+    "hexahedron20": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
+        9, 16, 18, 19, 17, 10, 12, 14, 15,
+    ],  # https://vtk.org/doc/release/4.2/html/classvtkQuadraticHexahedron.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+    "hexahedron27": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
+        9, 16, 18, 19, 17, 10, 12, 14, 15,
+        22, 23, 21, 24, 20, 25, 26,
+    ],
+    "wedge15": [
+        0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11
+    ],  # http://davis.lbl.gov/Manuals/VTK-4.5/classvtkQuadraticWedge.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+    "wedge18": [
+        0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11, 15, 17, 16
+    ],  # https://vtk.org/doc/nightly/html/classvtkBiQuadraticQuadraticWedge.html
+    "pyramid13": [0, 1, 2, 3, 4, 5, 8, 10, 6, 7, 9, 11, 12],
+    # fmt: on
+}
+
+_meshio_to_gmsh = {
+    cell_type: [order.index(i) for i in range(len(order))]
+    for cell_type, order in _gmsh_to_meshio.items()
+}
+
+
 def _gmsh_to_meshio_order(cell_type: str, idx: ArrayLike) -> np.ndarray:
-    # Gmsh cells are mostly ordered like VTK, with a few exceptions:
-    meshio_ordering = {
-        # fmt: off
-        "tetra10": [0, 1, 2, 3, 4, 5, 6, 7, 9, 8],
-        "hexahedron20": [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
-            9, 16, 18, 19, 17, 10, 12, 14, 15,
-        ],  # https://vtk.org/doc/release/4.2/html/classvtkQuadraticHexahedron.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
-        "hexahedron27": [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
-            9, 16, 18, 19, 17, 10, 12, 14, 15,
-            22, 23, 21, 24, 20, 25, 26,
-        ],
-        "wedge15": [
-            0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11
-        ],  # http://davis.lbl.gov/Manuals/VTK-4.5/classvtkQuadraticWedge.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
-        "pyramid13": [0, 1, 2, 3, 4, 5, 8, 10, 6, 7, 9, 11, 12],
-        # fmt: on
-    }
     idx = np.asarray(idx)
-    if cell_type not in meshio_ordering:
+    if cell_type not in _gmsh_to_meshio:
         return idx
-    return idx[:, meshio_ordering[cell_type]]
+    return idx[:, _gmsh_to_meshio[cell_type]]
 
 
 def _meshio_to_gmsh_order(cell_type: str, idx: ArrayLike) -> np.ndarray:
-    # Gmsh cells are mostly ordered like VTK, with a few exceptions:
-    gmsh_ordering = {
-        # fmt: off
-        "tetra10": [0, 1, 2, 3, 4, 5, 6, 7, 9, 8],
-        "hexahedron20": [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 16,
-            9, 17, 10, 18, 19, 12, 15, 13, 14,
-        ],
-        "hexahedron27": [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 16,
-            9, 17, 10, 18, 19, 12, 15, 13, 14,
-            24, 22, 20, 21, 23, 25, 26,
-        ],
-        "wedge15": [
-            0, 1, 2, 3, 4, 5, 6, 8, 12, 7, 13, 14, 9, 11, 10,
-        ],
-        "pyramid13": [0, 1, 2, 3, 4, 5, 8, 9, 6, 10, 7, 11, 12],
-        # fmt: on
-    }
     idx = np.asarray(idx)
-    if cell_type not in gmsh_ordering:
+    if cell_type not in _meshio_to_gmsh:
         return idx
-    return idx[:, gmsh_ordering[cell_type]]
+    return idx[:, _meshio_to_gmsh[cell_type]]
 
 
 def _write_physical_names(fh, field_data):

--- a/tests/test_gmsh.py
+++ b/tests/test_gmsh.py
@@ -1,6 +1,7 @@
 import copy
 import pathlib
 from functools import partial
+import textwrap
 
 import numpy as np
 import pytest
@@ -180,22 +181,35 @@ def test_reference_file_with_entities(
 
     helpers.write_read(tmp_path, writer, meshlane.gmsh.read, mesh, 1.0e-15)
 
+
 def test_convert_med_to_msh_preserves_metadata(tmp_path):
     """MED to MSH conversion must preserve tags and field_data."""
     from meshlane._mesh import CellBlock
     from meshlane.gmsh.main import _convert_med_tags_to_gmsh
 
-    points = np.array([
-        [0.0, 0.0],
-        [1.0, 0.0],
-        [0.0, 1.0],
-        [1.0, 1.0],
-        [2.0, 0.0],
-        [2.0, 1.0],
-    ])
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [2.0, 0.0],
+            [2.0, 1.0],
+        ]
+    )
 
     cells = [
-        CellBlock("triangle", np.array([[0, 1, 2], [1, 3, 2], [1, 4, 5], [1, 5, 3]])),
+        CellBlock(
+            "triangle",
+            np.array(
+                [
+                    [0, 1, 2],
+                    [1, 3, 2],
+                    [1, 4, 5],
+                    [1, 5, 3],
+                ]
+            ),
+        ),
     ]
 
     # Simulate MED data: 2 families, 2 geometric groups
@@ -233,3 +247,59 @@ def test_convert_med_to_msh_preserves_metadata(tmp_path):
     # field_data must be reconstructed
     assert "group_a" in converted.field_data
     assert "group_b" in converted.field_data
+
+
+def test_gmsh_wedge18_node_order(tmp_path):
+    """Gmsh prism18 (element type 13) node order, from the reference-element coordinates
+    gmsh.model.mesh.getElementProperties(13) reports, matched against meshlane's:
+      6 corners, 9 edge nodes, then the 3 quadrilateral face nodes.
+    A write/read round-trip cannot check this mapping, since writing and reading apply
+    permutations that are inverses of one another and cancel out. So read a file laid out
+    the way gmsh writes one and check where the nodes land.
+    """
+
+    path = tmp_path / "wedge18.msh"
+    path.write_text(textwrap.dedent("""\
+        $MeshFormat
+        2.2 0 8
+        $EndMeshFormat
+        $Nodes
+        18
+        1 0.0 0.0 0.0
+        2 1.0 0.0 0.0
+        3 0.0 1.0 0.0
+        4 0.0 0.0 1.0
+        5 1.0 0.0 1.0
+        6 0.0 1.0 1.0
+        7 0.5 0.0 0.0
+        8 0.5 0.5 0.0
+        9 0.0 0.5 0.0
+        10 0.5 0.0 1.0
+        11 0.5 0.5 1.0
+        12 0.0 0.5 1.0
+        13 0.0 0.0 0.5
+        14 1.0 0.0 0.5
+        15 0.0 1.0 0.5
+        16 0.5 0.0 0.5
+        17 0.5 0.5 0.5
+        18 0.0 0.5 0.5
+        $EndNodes
+        $Elements
+        1
+        1 13 2 0 1 1 2 3 4 5 6 7 9 13 8 14 15 10 12 11 16 18 17
+        $EndElements
+        """))
+
+    mesh = meshlane.gmsh.read(path)
+
+    assert len(mesh.cells) == 1
+    assert mesh.cells[0].type == "wedge18"
+
+    p = mesh.points[np.asarray(mesh.cells[0].data)[0]]
+    edges = [(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3), (0, 3), (1, 4), (2, 5)]
+    faces = [(0, 1, 4, 3), (1, 2, 5, 4), (2, 0, 3, 5)]
+
+    for k, (a, b) in enumerate(edges):
+        assert np.allclose(p[6 + k], (p[a] + p[b]) / 2), f"edge node {6 + k}"
+    for k, face in enumerate(faces):
+        assert np.allclose(p[15 + k], p[list(face)].mean(axis=0)), f"face node {15 + k}"


### PR DESCRIPTION
`_gmsh_to_meshio_order` and `_meshio_to_gmsh_order` both list `wedge15` but neither lists
`wedge18`, so Gmsh prism18 cells pass through unpermuted in both directions. The six vertices land
correctly and the mid-edge and face nodes do not, which makes it easy to miss: the mesh loads, and
only the higher-order geometry is wrong.

I derived the mapping rather than transcribing it —
`gmsh.model.mesh.getElementProperties(13)` gives gmsh's reference-element node coordinates and VTK
gives meshlane's, and matching them by position yields:

```python
"wedge18": [0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11, 15, 17, 16]
```

The same method re-derived `wedge15`, `hexahedron20`, `hexahedron27` and `tetra10` and reproduced
the existing entries exactly, so this only adds the missing one.

The two tables also have to stay exact inverses of each other, so the forward one is now the
single source and the reverse is derived with `order.index`. That reproduces all four hand-written
reverse entries **exactly** — the change is behaviour-preserving, and adding a cell type is now one
edit instead of two that can disagree.

`test_gmsh_wedge18_node_order` reads an inline msh 2.2 file whose element is laid out in gmsh's
node order and asserts every mid-edge node is its edge midpoint and every face node its face
centroid. A write/read round-trip cannot catch this, since the two permutations are inverses and
cancel out; deleting the `wedge18` entry makes exactly this test fail.

Reported upstream as nschloe/meshio#1517 (2025-04-09), no response.