### PR TITLE
fix(abaqus): element types, assembly support, lower memory

### DIFF
--- a/src/meshlane/abaqus/_abaqus.py
+++ b/src/meshlane/abaqus/_abaqus.py
@@ -8,7 +8,7 @@ import pathlib
 import numpy as np
 
 from ..__about__ import __version__
-from .._common import num_nodes_per_cell
+from .._common import num_nodes_per_cell, warn
 from .._exceptions import ReadError
 from .._files import is_buffer, open_file
 from .._helpers import register_format
@@ -90,9 +90,59 @@ abaqus_to_meshio_type = {
     "CAX4P": "quad",
     # 6-node quadratic
     "CPE6": "triangle6",
-    "DCOUP3D": "vertex",
 }
 meshio_to_abaqus_type = {v: k for k, v in abaqus_to_meshio_type.items()}
+
+# Read-only aliases: thermal (DC*), acoustic (AC*) and gasket (GK*) elements
+# share geometry with the displacement families. Added *after* the reverse map
+# so the writer still emits the canonical C3D*/S*/... names.
+abaqus_to_meshio_type.update(
+    {
+        "DC1D2": "line",
+        "DC1D3": "line3",
+        "DC2D3": "triangle",
+        "DC2D6": "triangle6",
+        "DC2D4": "quad",
+        "DC2D8": "quad8",
+        "DC3D4": "tetra",
+        "DC3D10": "tetra10",
+        "DC3D6": "wedge",
+        "DC3D15": "wedge15",
+        "DC3D8": "hexahedron",
+        "DC3D20": "hexahedron20",
+        "AC1D2": "line",
+        "AC2D3": "triangle",
+        "AC2D4": "quad",
+        "AC2D6": "triangle6",
+        "AC2D8": "quad8",
+        "AC3D4": "tetra",
+        "AC3D10": "tetra10",
+        "AC3D6": "wedge",
+        "AC3D8": "hexahedron",
+        "AC3D20": "hexahedron20",
+        "GK3D8": "hexahedron",
+        "GK3D6": "wedge",
+    }
+)
+
+# Non-mesh elements (connectors, springs, dashpots, masses, couplings, joints,
+# gaps): not cells, skipped on read.
+_NON_MESH_ELEMENTS = {"MASS", "ROTARYI"}
+_NON_MESH_PREFIXES = ("CONN", "SPRING", "DASHPOT", "DCOUP", "JOINT", "GAP")
+
+
+def _is_non_mesh(etype):
+    return etype in _NON_MESH_ELEMENTS or etype.startswith(_NON_MESH_PREFIXES)
+
+
+# Template for an instance that references no part (pure orphan mesh).
+_EMPTY_PART = {
+    "node_ids": np.array([], dtype=np.int64),
+    "coords": np.zeros((0, 3)),
+    "sections": [],
+    "nsets": {},
+    "elsets": {},
+}
 
 
 def read(filename):
@@ -165,29 +215,226 @@ def read_buffer(f):
 
     included = []              # meshes pulled in via *INCLUDE
 
+    def _add_block(cell_type, id_array, conn_array):
+        # register one cell block from numpy id + connectivity arrays.
+        # conn_array holds raw Abaqus node ids; they're converted to
+        # points-array indices in one pass at the end (see finalize / _resolve).
+        b = len(cell_types)
+        cell_types.append(cell_type)
+        cell_rows.append(conn_array)
+        for i, gid in enumerate(id_array.tolist()):
+            elem_id_to_block[gid] = b
+            elem_id_to_local[gid] = i
+        return b
+
     def add_elements(cell_type, rows, elset_name):
         if not rows:
             return
-        b = len(cell_types)
-        cell_types.append(cell_type)
-        cell_rows.append([])
-        block = cell_rows[b]
-        for r in rows:
-            gid = r[0]
-            elem_id_to_block[gid] = b
-            elem_id_to_local[gid] = len(block)
-            block.append(r[1:])
+        conn = np.array([r[1:] for r in rows], dtype=np.int64)
+        ids = np.fromiter((r[0] for r in rows), dtype=np.int64, count=len(rows))
+        _add_block(cell_type, ids, conn)
         if elset_name is not None:
-            elset_from_element.setdefault(elset_name, []).extend(r[0] for r in rows)
+            elset_from_element.setdefault(elset_name, []).extend(ids.tolist())
             if elset_name not in elset_order:
                 elset_order.append(elset_name)
+
+    # ---- Abaqus assembly (parts + instances) support ----
+    # A *Part numbers its nodes and elements locally (each part starts at 1), and
+    # a *Instance drops a positioned copy of that part into the model. So the same
+    # local id (eg. node 1) exists once per instance and would collide if stored
+    # as-is. On each instantiation we therefore renumber every node and element to
+    # a new, globally-unique id. Once ids are unique, an instance is just another
+    # batch of nodes and cells: the ordinary finalize step (id resolver and sets)
+    # handles it with no assembly-specific code.
+    parts = {}            # part name -> template dict
+    instantiated_parts = set()
+    inst_maps = {}        # instance name -> (local_node_id->syn, local_elem_id->syn)
+    asm_node_syn = {}     # assembly-level (orphan) node id -> syn
+    syn = [1_000_000_000]
+
+    def _add_nset(name, syn_ids):
+        if not syn_ids:
+            return
+        arr = np.array(syn_ids, dtype=np.int64)
+        prev = point_sets_raw.get(name)
+        point_sets_raw[name] = np.concatenate([prev, arr]) if prev is not None else arr
+
+    def _add_elset(name, syn_ids):
+        if not syn_ids:
+            return
+        if name not in elset_order:
+            elset_order.append(name)
+        arr = np.array(syn_ids, dtype=np.int64)
+        prev = elset_numeric.get(name)
+        elset_numeric[name] = np.concatenate([prev, arr]) if prev is not None else arr
+
+    def _instantiate(part, data_lines, iname):
+        node_ids = np.asarray(part["node_ids"], dtype=np.int64)
+        coords = np.asarray(part["coords"], dtype=float)
+        n = len(node_ids)
+        if coords.size:
+            coords = _instance_transform(coords, data_lines)
+        base = len(points)
+        points.extend(coords.tolist())
+        node_syn = np.arange(syn[0], syn[0] + n, dtype=np.int64)
+        syn[0] += n
+        point_ids.update(zip(node_syn.tolist(), range(base, base + n)))
+        lid2syn = dict(zip(node_ids.tolist(), node_syn.tolist()))
+        if n:
+            order = np.argsort(node_ids)
+            sorted_ids = node_ids[order]
+            syn_sorted = node_syn[order]
+        eid2syn = {}
+        for ctype, ids_arr, conn_arr in part["sections"]:
+            ids_arr = np.asarray(ids_arr, dtype=np.int64)
+            conn_arr = np.asarray(conn_arr, dtype=np.int64)
+            m = len(ids_arr)
+            elem_syn = np.arange(syn[0], syn[0] + m, dtype=np.int64)
+            syn[0] += m
+            pos = np.searchsorted(sorted_ids, conn_arr.ravel())
+            syn_conn = syn_sorted[pos].reshape(conn_arr.shape)
+            _add_block(ctype, elem_syn, syn_conn)
+            eid2syn.update(zip(ids_arr.tolist(), elem_syn.tolist()))
+        for sname, ids in part["nsets"].items():
+            _add_nset(sname, [lid2syn[i] for i in ids if i in lid2syn])
+        for sname, eids in part["elsets"].items():
+            _add_elset(sname, [eid2syn[e] for e in eids if e in eid2syn])
+        inst_maps[iname] = (lid2syn, eid2syn)
+
+    def _map_nset(iname, sname, ids):
+        m = inst_maps[iname][0] if iname in inst_maps else asm_node_syn
+        _add_nset(sname, [m[i] for i in ids if i in m])
+
+    def _map_elset(iname, sname, ids):
+        if iname in inst_maps:
+            m = inst_maps[iname][1]
+            _add_elset(sname, [m[i] for i in ids if i in m])
+
+    def _read_assembly(line):
+        line = f.readline()
+        while line:
+            if line.startswith("**"):
+                line = f.readline()
+                continue
+            kw = line.partition(",")[0].strip().replace("*", "").upper()
+            if kw == "END ASSEMBLY":
+                line = f.readline()
+                break
+            if kw == "INSTANCE":
+                pm = get_param_map(line, required_keys=["NAME"])
+                iname, pname = pm.get("NAME"), pm.get("PART")
+                data_lines = []
+                line = f.readline()
+                while line and not _ends_block(line):
+                    if not line.startswith("**") and line.strip():
+                        data_lines.append(
+                            [float(x) for x in line.replace(",", " ").split()]
+                        )
+                    line = f.readline()
+                # instance-level additions (Abaqus orphan-mesh style)
+                ins_nid, ins_xyz, ins_sec = [], [], []
+                ins_nsets, ins_elsets = {}, {}
+                while line:
+                    nkw = line.partition(",")[0].strip().replace("*", "").upper()
+                    if nkw == "END INSTANCE":
+                        line = f.readline()
+                        break
+                    if nkw == "NODE":
+                        pts, pid, _, line = _read_nodes(f)
+                        ins_nid.extend(pid.keys())
+                        ins_xyz.extend(pts)
+                    elif nkw == "ELEMENT":
+                        pm2 = get_param_map(line, required_keys=["TYPE"])
+                        ctype, rows, line = _read_cells(f, pm2)
+                        if ctype is not None:
+                            ins_sec.append(
+                                (
+                                    ctype,
+                                    np.fromiter(
+                                        (r[0] for r in rows),
+                                        dtype=np.int64,
+                                        count=len(rows),
+                                    ),
+                                    np.array([r[1:] for r in rows], dtype=np.int64),
+                                )
+                            )
+                            els = pm2.get("ELSET")
+                            if els:
+                                ins_elsets.setdefault(els, []).extend(
+                                    r[0] for r in rows
+                                )
+                    elif nkw == "NSET":
+                        pm2 = get_param_map(line, required_keys=["NSET"])
+                        ids, _, line = _read_set(f, pm2)
+                        ins_nsets.setdefault(pm2["NSET"], []).extend(
+                            int(i) for i in ids
+                        )
+                    elif nkw == "ELSET":
+                        pm2 = get_param_map(line, required_keys=["ELSET"])
+                        ids, _, line = _read_set(f, pm2)
+                        ins_elsets.setdefault(pm2["ELSET"], []).extend(
+                            int(i) for i in ids
+                        )
+                    else:
+                        line = _skip_block(f)
+                part = parts.get(pname)
+                if not (ins_nid or ins_sec or ins_nsets or ins_elsets):
+                    # mesh lives entirely in the part: instantiate it directly
+                    # (no per-instance copy).
+                    _instantiate(part or _EMPTY_PART, data_lines, iname)
+                else:
+                    p = part or _EMPTY_PART
+                    if len(p["node_ids"]) == 0:
+                        node_ids = np.array(ins_nid, dtype=np.int64)
+                        coords = (
+                            np.array(ins_xyz, dtype=float)
+                            if ins_xyz
+                            else np.zeros((0, 3))
+                        )
+                    elif ins_nid:
+                        node_ids = np.concatenate(
+                            [p["node_ids"], np.array(ins_nid, dtype=np.int64)]
+                        )
+                        coords = np.concatenate(
+                            [p["coords"], np.array(ins_xyz, dtype=float)]
+                        )
+                    else:
+                        node_ids, coords = p["node_ids"], p["coords"]
+                    tmpl = {
+                        "node_ids": node_ids,
+                        "coords": coords,
+                        "sections": list(p["sections"]) + ins_sec,
+                        "nsets": {**p["nsets"], **ins_nsets},
+                        "elsets": {**p["elsets"], **ins_elsets},
+                    }
+                    _instantiate(tmpl, data_lines, iname)
+                if pname:
+                    instantiated_parts.add(pname)
+            elif kw == "NODE":
+                pts, pid, _, line = _read_nodes(f)
+                for lid in pid.keys():
+                    sid = syn[0]
+                    syn[0] += 1
+                    point_ids[sid] = len(points)
+                    points.append(pts[pid[lid]])
+                    asm_node_syn[lid] = sid
+            elif kw == "NSET":
+                pm = get_param_map(line, required_keys=["NSET"])
+                ids, _, line = _read_set(f, pm)
+                _map_nset(pm.get("INSTANCE"), pm["NSET"], ids)
+            elif kw == "ELSET":
+                pm = get_param_map(line, required_keys=["ELSET"])
+                ids, _, line = _read_set(f, pm)
+                _map_elset(pm.get("INSTANCE"), pm["ELSET"], ids)
+            else:
+                line = f.readline()
+        return line
 
     line = f.readline()
     while True:
         if not line:  # EOF
             break
 
-        # Comments
         if line.startswith("**"):
             line = f.readline()
             continue
@@ -225,9 +472,21 @@ def read_buffer(f):
             if len(out.points) > 0:
                 included.append(out)
             line = f.readline()
+        elif keyword == "PART":
+            pname, pdata, line = _read_part(f, line)
+            parts[pname] = pdata
+        elif keyword == "ASSEMBLY":
+            line = _read_assembly(line)
+            counter = len(points)
         else:
             # There are just too many Abaqus keywords to explicitly skip them.
             line = f.readline()
+
+    # a *Part defined but never placed by an *Instance (e.g. a part-only .inp
+    # with no assembly) is still emitted, at identity.
+    for pname, pdata in parts.items():
+        if pname not in instantiated_parts:
+            _instantiate(pdata, [], pname)
 
     # finalize points & cells
     points = np.asarray(points, dtype=float)
@@ -235,8 +494,7 @@ def read_buffer(f):
 
     cells = []
     for b, ctype in enumerate(cell_types):
-        raw = np.array(cell_rows[b], dtype=np.int64)
-        cells.append(CellBlock(ctype, _resolve(node_keys, node_vals, raw)))
+        cells.append(CellBlock(ctype, _resolve(node_keys, node_vals, cell_rows[b])))
     n_blocks = len(cells)
 
     #  helper: list of element ids -> per-block local-index arrays
@@ -263,7 +521,13 @@ def read_buffer(f):
             for ref in elset_byname[name]:
                 target = ci_resolved.get(ref.upper())
                 if target is None:
-                    raise ReadError(f"Unknown cell set '{ref}'")
+                    # A referenced set may belong to elements we skipped
+                    # (e.g. connectors); keep what resolves instead of aborting.
+                    warn(
+                        f"Abaqus: cell set {name!r} references unknown set "
+                        f"{ref!r}; skipping that reference."
+                    )
+                    continue
                 for b, arr in enumerate(cell_sets[target]):
                     merged[b].append(arr)
             cell_sets[name] = [
@@ -335,13 +599,27 @@ def _read_nodes(f, points=None, point_ids=None, counter=0):
     return points, point_ids, counter, line
 
 
+def _skip_block(f):
+    # Read and discard the current data block; return the keyword line that ends
+    # it (or an empty string at EOF).
+    while True:
+        line = f.readline()
+        if not line or _ends_block(line):
+            return line
+
+
 def _read_cells(f, params_map):
     # Abaqus element types are case-insensitive; normalise to match the map keys.
     etype = params_map["TYPE"].upper()
-    if etype not in abaqus_to_meshio_type:
-        raise ReadError(f"Element type not available: {etype}")
+    cell_type = abaqus_to_meshio_type.get(etype)
+    if cell_type is None:
+        # Not a mesh cell: known non-mesh elements (connectors, springs, masses,
+        # couplings, ...) are skipped silently; unknown types are skipped with a
+        # warning. Either way, consume the block so reading can continue.
+        if not _is_non_mesh(etype):
+            warn(f"Abaqus: skipping unsupported element type {etype!r}.")
+        return None, [], _skip_block(f)
 
-    cell_type = abaqus_to_meshio_type[etype]
     num_data = num_nodes_per_cell[cell_type] + 1  # ElementID + NodeIDs
 
     rows = []
@@ -458,7 +736,7 @@ def _read_set(f, params_map):
         else:
             # set defined from other sets, listed by name; a single line may
             # list several (case-insensitive resolution happens at the caller)
-            set_names += [k for k in line if k]
+            set_names += [k.strip() for k in line if k.strip()]
 
     set_ids = np.array(set_ids, dtype="int32")
     if "GENERATE" in params_map:
@@ -466,6 +744,112 @@ def _read_set(f, params_map):
             raise ReadError(set_ids)
         set_ids = np.arange(set_ids[0], set_ids[1] + 1, set_ids[2], dtype="int32")
     return set_ids, set_names, line
+
+
+def _rotate_about_axis(coords, a, b, angle_deg):
+    # Rotate points by angle_deg (degrees) about the axis from point a to point b.
+    a = np.asarray(a, dtype=float)
+    axis = np.asarray(b, dtype=float) - a
+    norm = np.linalg.norm(axis)
+    if norm == 0.0:
+        return coords
+    axis = axis / norm
+    th = np.radians(angle_deg)
+    p = coords - a
+    c = np.cos(th)
+    s = np.sin(th)
+    return a + p * c + np.cross(axis, p) * s + np.outer(p @ axis, axis) * (1.0 - c)
+
+
+def _instance_transform(coords, data_lines):
+    # Abaqus *INSTANCE: an optional translation line, then an optional rotation
+    # line (point a, point b, angle). Translation is applied first, then rotation.
+    coords = np.asarray(coords, dtype=float)
+    if coords.size == 0:
+        return coords
+    dim = coords.shape[1]
+    if len(data_lines) >= 1 and len(data_lines[0]) >= dim:
+        coords = coords + np.asarray(data_lines[0][:dim], dtype=float)
+    if dim == 3 and len(data_lines) >= 2 and len(data_lines[1]) >= 7:
+        d = data_lines[1]
+        coords = _rotate_about_axis(coords, d[0:3], d[3:6], d[6])
+    return coords
+
+
+def _read_part(f, line):
+    """Read a `*Part` block (local node/element numbering) into a template dict."""
+    name = get_param_map(line, required_keys=["NAME"]).get("NAME")
+    node_ids, coords = [], []
+    sections = []          # [(cell_type, [(elem_id, [node_ids]), ...]), ...]
+    nsets, elsets = {}, {}
+    line = f.readline()
+    while line:
+        if line.startswith("**"):
+            line = f.readline()
+            continue
+        kw = line.partition(",")[0].strip().replace("*", "").upper()
+        if kw == "END PART":
+            line = f.readline()
+            break
+        if kw == "NODE":
+            pts, pid, _, line = _read_nodes(f)
+            node_ids.extend(pid.keys())
+            coords.extend(pts)
+        elif kw == "ELEMENT":
+            pm = get_param_map(line, required_keys=["TYPE"])
+            ctype, rows, line = _read_cells(f, pm)
+            if ctype is not None:
+                sections.append((ctype, [(r[0], r[1:]) for r in rows]))
+                els = pm.get("ELSET")
+                if els:
+                    elsets.setdefault(els, []).extend(r[0] for r in rows)
+        elif kw == "NSET":
+            pm = get_param_map(line, required_keys=["NSET"])
+            ids, _, line = _read_set(f, pm)
+            if ids.size:
+                nsets.setdefault(pm["NSET"], []).extend(int(i) for i in ids)
+        elif kw == "ELSET":
+            pm = get_param_map(line, required_keys=["ELSET"])
+            ids, _, line = _read_set(f, pm)
+            if ids.size:
+                elsets.setdefault(pm["ELSET"], []).extend(int(i) for i in ids)
+        elif kw == "INCLUDE":
+            # a part's mesh may live in an included file; pull in its
+            # nodes/elements (sets from includes are not carried over).
+            inc = pathlib.Path(line.split("=")[-1].strip())
+            if not inc.exists() and hasattr(f, "name"):
+                inc = pathlib.Path(f.name).parent / inc
+            sub = read(inc)
+            start = (max(node_ids) + 1) if node_ids else 1
+            for i, p in enumerate(sub.points):
+                node_ids.append(start + i)
+                coords.append([float(x) for x in p])
+            for cb in sub.cells:
+                elems = [
+                    (k + 1, [start + int(x) for x in row])
+                    for k, row in enumerate(cb.data)
+                ]
+                sections.append((cb.type, elems))
+            line = f.readline()
+        else:
+            line = f.readline()
+    # store the template compactly (numpy) so many part templates can coexist
+    # with the instantiated mesh without blowing up memory.
+    np_sections = [
+        (
+            ct,
+            np.fromiter((e[0] for e in elems), dtype=np.int64, count=len(elems)),
+            np.array([e[1] for e in elems], dtype=np.int64),
+        )
+        for ct, elems in sections
+    ]
+    return name, {
+        "node_ids": np.array(node_ids, dtype=np.int64),
+        "coords": np.array(coords, dtype=float) if coords else np.zeros((0, 3)),
+        "sections": np_sections,
+        "nsets": nsets,
+        "elsets": elsets,
+    }, line
 
 
 def write(

--- a/tests/test_abaqus.py
+++ b/tests/test_abaqus.py
@@ -76,3 +76,94 @@ def test_elset(tmp_path):
     for k, v in mesh_ref.cell_sets.items():
         for ic in range(len(mesh_ref.cells)):
             assert np.allclose(v[ic], mesh.cell_sets[k][ic])
+
+
+def _nodes(n):
+    return "*NODE\n" + "".join(
+        f"{i}, {float(i)}, {float(i % 3)}, {float(i % 2)}\n" for i in range(1, n + 1)
+    )
+
+
+def _write_deck(path, n_nodes, body):
+    path.write_text(_nodes(n_nodes) + body)
+    return path
+
+
+def test_thermal_and_gasket_types(tmp_path):
+    # thermal (DC3D*) and gasket (GK3D8) map to their geometry
+    body = (
+        "*ELEMENT, TYPE=DC3D10, ELSET=T\n1, 1,2,3,4,5,6,7,8,9,10\n"
+        "*ELEMENT, TYPE=DC3D8, ELSET=H\n2, 1,2,3,4,5,6,7,8\n"
+        "*ELEMENT, TYPE=GK3D8, ELSET=G\n3, 1,2,3,4,5,6,7,8\n"
+    )
+    f = _write_deck(tmp_path / "t.inp", 10, body)
+    mesh = meshlane.abaqus.read(f)
+    counts = {}
+    for c in mesh.cells:
+        counts[c.type] = counts.get(c.type, 0) + len(c.data)
+    assert counts == {"tetra10": 1, "hexahedron": 2}
+
+
+def test_skip_non_mesh_elements(tmp_path):
+    # connectors/springs/masses are not cells and must be dropped (no error)
+    body = (
+        "*ELEMENT, TYPE=C3D4, ELSET=S\n1, 1,2,3,4\n"
+        "*ELEMENT, TYPE=SPRING2, ELSET=SP\n2, 1,2\n"
+        "*ELEMENT, TYPE=MASS, ELSET=M\n3, 1\n"
+        "*ELEMENT, TYPE=CONN3D2, ELSET=C\n4, 1,2\n"
+        "*ELEMENT, TYPE=DCOUP3D, ELSET=D\n5, 1\n"
+    )
+    f = _write_deck(tmp_path / "s.inp", 4, body)
+    mesh = meshlane.abaqus.read(f)
+    assert {c.type for c in mesh.cells} == {"tetra"}
+
+
+def test_unknown_type_warns_and_skips(tmp_path, capsys):
+    # an unrecognized type is skipped with a warning, the rest still reads
+    body = (
+        "*ELEMENT, TYPE=C3D4, ELSET=S\n1, 1,2,3,4\n"
+        "*ELEMENT, TYPE=FOOBAR9, ELSET=X\n2, 1,2,3,4\n"
+    )
+    f = _write_deck(tmp_path / "u.inp", 4, body)
+    mesh = meshlane.abaqus.read(f)
+    assert {c.type for c in mesh.cells} == {"tetra"}
+    assert "FOOBAR9" in capsys.readouterr().err
+
+
+def test_assembly_instances(tmp_path):
+    # a part instanced three times: identity, translated, and rotated. Each
+    # instance keeps its own node numbering, so the copies must not collide.
+    deck = """*Part, name=P1
+*Node
+1, 0.0, 0.0, 0.0
+2, 1.0, 0.0, 0.0
+3, 0.0, 1.0, 0.0
+4, 0.0, 0.0, 1.0
+*Element, type=C3D4
+1, 1, 2, 3, 4
+*Nset, nset=CORNER
+1,
+*End Part
+*Assembly, name=Assembly
+*Instance, name=I1, part=P1
+*End Instance
+*Instance, name=I2, part=P1
+10.0, 0.0, 0.0
+*End Instance
+*Instance, name=I3, part=P1
+0.0, 0.0, 0.0
+0.0,0.0,0.0, 0.0,0.0,1.0, 90.0
+*End Instance
+*Nset, nset=TOP, instance=I2
+2
+*End Assembly
+"""
+    f = tmp_path / "asm.inp"
+    f.write_text(deck)
+    m = meshlane.read(f)
+    assert len(m.points) == 12                       # 3 instances x 4 nodes
+    assert sum(len(c.data) for c in m.cells) == 3    # 3 tetra
+    assert np.allclose(m.points[4], [10.0, 0.0, 0.0])            # I2 translated
+    assert np.allclose(m.points[9], [0.0, 1.0, 0.0], atol=1e-9)  # I3 (1,0,0)->(0,1,0)
+    assert len(m.point_sets["CORNER"]) == 3          # part set, unioned over 3
+    assert np.allclose(m.points[m.point_sets["TOP"][0]], [11.0, 0.0, 0.0])


### PR DESCRIPTION
## Issue

A few industrial Abaqus input files broke the reader three ways :

- **Unknown element types stopped the read:** The reader knew only the stress families and aborted on the first thermal, gasket, or connector element it hit.
- **Assembly-based input files read with corrupted connectivity:** The reader ignored `*Part`/`*Instance` and read every part into one shared node table. Since each part restarts node numbering at 1, nodes from different parts collided and elements ended up pointing at the wrong nodes.
- **Excessive memory use:** The reader used roughly 20x the file size, so large files exhausted available memory before finishing.
## Fix

- **Element types:** Map thermal (`DC*`), acoustic (`AC*`) and gasket (`GK*`) to their geometry (as they are real cells). Skip non-mesh elements (springs, masses, connectors, dashpots, couplings, joints, gaps: not cells). Warn and skip genuinely unknown types instead of aborting. Tolerate `*Nset`/`*Elset` that reference a missing set. 
- **Assembly:** Actually parse `*Part` and `*Instance` instead of ignoring them. Each part is read once in its own local numbering, and each instance places a copy of it with the instance's translation and rotation. Every copied node and element is renumbered to a new, unique id, so a part used by several instances no longer collides with itself. Group names that repeat across instances (`*Nset`/`*Elset`, including assembly-level `instance=`ones) are merged into a single mesh group. Edge cases are handled too: a mesh defined directly inside an `*Instance`, an `*Include` inside a part, and a part that is never instanced.
- **Memory:** Keep the mesh connectivity and the per-part templates as numpy arrays instead of Python lists of ints, which cost about 4x the memory per node id. A single `_add_block` helper now registers every block, and each instance remaps its node ids with `searchsorted` instead of a Python loop.

