### PR TITLE
feat(numpy): support numpy 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "meshlane"
 version = "5.4.3"
 description = "I/O for many mesh formats"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE.txt"}
 keywords = [
   "mesh",
@@ -30,8 +30,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -40,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "importlib_metadata; python_version<'3.8'",
-  "numpy>=1.20.0,<2",
+  "numpy>=1.20.0",
   "rich",
 ]
 

--- a/src/meshlane/dolfin/_dolfin.py
+++ b/src/meshlane/dolfin/_dolfin.py
@@ -207,7 +207,8 @@ def _write_cell_data(filename, dim, cell_data):
     )
 
     for k, value in enumerate(cell_data):
-        ET.SubElement(mesh_function, "entity", index=str(k), value=repr(value))
+        # str (not repr): numpy 2 scalar repr is "np.float64(...)"; str round-trips.
+        ET.SubElement(mesh_function, "entity", index=str(k), value=str(value))
 
     tree = ET.ElementTree(dolfin)
     tree.write(filename)

--- a/src/meshlane/gmsh/common.py
+++ b/src/meshlane/gmsh/common.py
@@ -273,7 +273,8 @@ def _write_data(fh, tag, name, data, binary):
         tmp.tofile(fh)
         fh.write(b"\n")
     else:
-        fmt = " ".join(["{}"] + ["{!r}"] * num_components) + "\n"
+        # {} (not {!r}): numpy 2 scalar repr is "np.float64(...)"; str round-trips.
+        fmt = " ".join(["{}"] + ["{}"] * num_components) + "\n"
         # TODO unify
         if num_components == 1:
             for k, x in enumerate(data):

--- a/src/meshlane/mdpa/_mdpa.py
+++ b/src/meshlane/mdpa/_mdpa.py
@@ -418,7 +418,8 @@ def _write_data(fh, tag, name, data, binary):
         data = data[:, 0]
 
     # Actually write the data
-    fmt = " ".join(["{}"] + ["{!r}"] * num_components) + "\n"
+    # {} (not {!r}): numpy 2 scalar repr is "np.float64(...)"; str round-trips.
+    fmt = " ".join(["{}"] + ["{}"] * num_components) + "\n"
     # TODO unify
     if num_components == 1:
         for k, x in enumerate(data):

--- a/src/meshlane/stl/_stl.py
+++ b/src/meshlane/stl/_stl.py
@@ -34,7 +34,9 @@ def read(filename):
             return _read_ascii(f)
 
         f.read(80)
-        num_triangles = np.fromfile(f, count=1, dtype="<u4")[0]
+        # cast to Python int: numpy 2 (NEP 50) keeps the uint32 dtype, so
+        # num_triangles * 50 overflows and wraps for large files.
+        num_triangles = int(np.fromfile(f, count=1, dtype="<u4")[0])
         # for each triangle, one has 3 float32 (facet normal), 9 float32 (facet),
         # and 1 int16 (attribute count), 50 bytes in total
         if 84 + num_triangles * 50 == filesize_bytes:

--- a/src/meshlane/ugrid/_ugrid.py
+++ b/src/meshlane/ugrid/_ugrid.py
@@ -145,7 +145,9 @@ def read_buffer(f, file_type):
 def _write_section(f, file_type, array, dtype):
     if file_type["type"] == "ascii":
         ncols = array.shape[1]
-        fmt = " ".join(["%r"] * ncols)
+        # %s (not %r): numpy 2 changed scalar repr to "np.float64(...)"; str
+        # still yields the round-trippable plain value.
+        fmt = " ".join(["%s"] * ncols)
         np.savetxt(f, array, fmt=fmt)
     else:
         array.astype(dtype).tofile(f)


### PR DESCRIPTION
## Problem

meshlane pinned `numpy<2`. Tests with numpy 2.x showed 25 tests failed (gmsh, ugrid, dolfin):

```
ValueError: string or file could not be read to its end due to unmatched data
```

The cause is on the write side. numpy 2 (NEP 51) changed scalar `repr` from `4` to `np.int64(4)`, so writers that formatted numpy scalars through `repr` (`%r`, `{!r}`, `repr()`) wrote tokens like `np.float64(0.0)`, which the round-trip reader could not parse. `str` is unaffected and still round-trips.

## Fix

- Writers: `repr` -> `str` in the four sites that formatted numpy scalars (`ugrid` `%r`->`%s`, `gmsh/common` and `mdpa` `{!r}`->`{}`, `dolfin` `repr()`->`str()`).
- `stl`: cast `num_triangles` to Python `int` (numpy 2 NEP 50 keeps `uint32`, so `* 50` could overflow for very large binary STL files).
- Packaging: drop the `numpy<2` cap; bump `requires-python` to `>=3.10`.
