### PR TITLE
fix(med): encode text metadata as UTF-8

### DIFF
--- a/src/meshlane/med/_med.py
+++ b/src/meshlane/med/_med.py
@@ -92,6 +92,18 @@ def _med_group_key(cell_type):
 
 numpy_void_str = np.bytes_("")
 
+
+def _med_str(raw):
+    # MED stores text as 8-bit char arrays. Decode as UTF-8 (what Salome and
+    # code_aster write and expect), falling back to Latin-1 for older files.
+    if not isinstance(raw, (bytes, bytearray)):
+        raw = bytes((int(x) & 0xFF) for x in np.asarray(raw).ravel())
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1")
+
+
 MED_FLOAT32 = 4
 MED_FLOAT64 = 6
 MED_INT32 = 24
@@ -371,9 +383,9 @@ def read(filename):
         raise ReadError(f"Must only contain exactly 1 mesh, found {len(meshes)}.")
     mesh_name = list(meshes)[0]
     mesh = mesh_ensemble[mesh_name]
-    mesh_description = mesh.attrs.get("DES", b"").decode("latin-1").strip().rstrip("\x00")
-    mesh_unit_time   = mesh.attrs.get("UNT", b"").decode("latin-1").strip().rstrip("\x00")
-    mesh_unit_coords = mesh.attrs.get("UNI", b"").decode("latin-1").strip().rstrip("\x00")
+    mesh_description = _med_str(mesh.attrs.get("DES", b"")).strip().rstrip("\x00")
+    mesh_unit_time   = _med_str(mesh.attrs.get("UNT", b"")).strip().rstrip("\x00")
+    mesh_unit_coords = _med_str(mesh.attrs.get("UNI", b"")).strip().rstrip("\x00")
 
     dim = mesh.attrs["ESP"]
 
@@ -692,7 +704,7 @@ def _read_families(fas_data):
         nom_dataset = node_set["GRO"]["NOM"][()]
         name = [None] * n_subsets
         for i in range(n_subsets):
-            name[i] = "".join([chr(x) for x in nom_dataset[i]]).strip().rstrip("\x00")
+            name[i] = _med_str(nom_dataset[i]).strip().rstrip("\x00")
         families[set_id] = name
         group_names[set_id] = group_name
     return families, group_names
@@ -735,13 +747,13 @@ def write(filename, mesh, med_version="4.1.0", **kwargs):
     desc = getattr(mesh, "description", None)
     if not desc:
         desc = "Mesh created with meshlane"
-    med_mesh.attrs.create("UNT", np.bytes_(unt.encode("latin-1")) if unt else numpy_void_str)
-    med_mesh.attrs.create("UNI", np.bytes_(uni.encode("latin-1")) if uni else numpy_void_str)
+    med_mesh.attrs.create("UNT", np.bytes_(unt.encode("utf-8")) if unt else numpy_void_str)
+    med_mesh.attrs.create("UNI", np.bytes_(uni.encode("utf-8")) if uni else numpy_void_str)
     med_mesh.attrs.create("SRT", 1)  # sorting type MED_SORT_ITDT
     # component names:
     names = ["X", "Y", "Z"][: mesh.points.shape[1]]
     med_mesh.attrs.create("NOM", np.bytes_("".join(f"{name:<16}" for name in names)))
-    med_mesh.attrs.create("DES", np.bytes_(desc.encode("latin-1")))
+    med_mesh.attrs.create("DES", np.bytes_(desc.encode("utf-8")))
     med_mesh.attrs.create("TYP", 0)  # mesh type (MED_NON_STRUCTURE)
 
     # Time-step
@@ -1190,7 +1202,7 @@ def _write_families(fm_group, tags, group_names=None):
         # <= MED_NAME_SIZE (64) octets. Les libellés lisibles sont
         # stockés dans GRO/NOM, pas ici.
         gname = gname.replace("/", "_")
-        if len(gname.encode("latin-1", "replace")) > 64:
+        if len(gname.encode("utf-8", "replace")) > 64:
             gname = f"FAM_{set_id}"
         family = fm_group.create_group(gname, track_order=True)
         family.attrs.create("NUM", set_id)
@@ -1206,7 +1218,7 @@ def _write_families(fm_group, tags, group_names=None):
         )
         buf = np.full((len(name), 80), ord(" "), dtype="i1")
         for i, n in enumerate(name):
-            name_bytes = n.encode("latin-1", "replace")
+            name_bytes = n.encode("utf-8", "replace")
             if len(name_bytes) > 80:
                 raise WriteError(
                     f"Family name '{n}' is too long for MED format (max 80 bytes)."

--- a/src/meshlane/med/_medmulti.py
+++ b/src/meshlane/med/_medmulti.py
@@ -35,6 +35,7 @@ from ._med import (
     numpy_to_med_type,
     numpy_void_str,
     MED_FLOAT64,
+    _med_str,
     _reorder_med_cells,
     _write_families,
     _read_families,
@@ -111,7 +112,7 @@ def _bytes_attr(value, fallback=numpy_void_str):
         return fallback
     if isinstance(value, (bytes, np.bytes_)):
         return np.bytes_(value)
-    return np.bytes_(str(value).encode("latin-1"))
+    return np.bytes_(str(value).encode("utf-8"))
 
 
 def _create_field_group(fields, hdf5_name, mesh_name, first_data,
@@ -432,9 +433,9 @@ def _read_single_mesh(f, name):
     dim = mesh_grp.attrs["ESP"]
 
     # metadata read from the top mesh group (before descending into a step)
-    description = mesh_grp.attrs.get("DES", b"").decode("latin-1").strip().rstrip("\x00")
-    unit_time = mesh_grp.attrs.get("UNT", b"").decode("latin-1").strip().rstrip("\x00")
-    unit_coords = mesh_grp.attrs.get("UNI", b"").decode("latin-1").strip().rstrip("\x00")
+    description = _med_str(mesh_grp.attrs.get("DES", b"")).strip().rstrip("\x00")
+    unit_time = _med_str(mesh_grp.attrs.get("UNT", b"")).strip().rstrip("\x00")
+    unit_coords = _med_str(mesh_grp.attrs.get("UNI", b"")).strip().rstrip("\x00")
 
     if "NOE" not in mesh_grp:
         time_step = list(mesh_grp.keys())

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1142,13 +1142,14 @@ def test_step_metadata_roundtrip(tmp_path):
             )
 
 
-def test_metadata_latin1_roundtrip(tmp_path):
-    """Non-ASCII Latin-1 metadata (µm, °C, French accents) must round-trip.
-    MED stores strings as 8-bit char arrays, so Latin-1 is the supported
-    encoding. Plain ASCII and Latin-1 supplements must both be preserved
-    without UnicodeEncodeError on write.
+def test_metadata_utf8_roundtrip(tmp_path):
+    """Non-ASCII metadata (µm, French accents) must round-trip and be stored as
+    UTF-8, so external readers (like Salome 9, code_aster, etc.) accept it. Latin-1
+    bytes (e.g. é = 0xE9) crash some solvers UTF-8 decoding.
     """
-    filename = tmp_path / "latin1.med"
+    import h5py
+
+    filename = tmp_path / "utf8.med"
     mesh = copy.deepcopy(helpers.tri_mesh)
     mesh.unit_coords = "µm"
     mesh.unit_time = "µs"
@@ -1160,6 +1161,13 @@ def test_metadata_latin1_roundtrip(tmp_path):
     assert out.unit_coords == "µm"
     assert out.unit_time == "µs"
     assert out.description == "Maillage généré par Salome"
+
+    # stored as UTF-8 (é -> 0xC3 0xA9)
+    with h5py.File(filename, "r") as f:
+        name = list(f["ENS_MAA"].keys())[0]
+        des = bytes(f["ENS_MAA"][name].attrs["DES"])
+    assert b"\xc3\xa9" in des
+    assert des.decode("utf-8").startswith("Maillage")
 
 
 def test_med_multi_write_read_two_meshes(tmp_path):


### PR DESCRIPTION
## Problem

meshlane wrote MED text (mesh description, units, group/family names) as Latin-1. Softwares like code_aster reads MED names as UTF-8, so a group name with an accented character crashes it:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 29
```

## Fix

- Write MED `DES`/`UNT`/`UNI` and family `GRO/NOM` as **UTF-8** (was Latin-1). ASCII is unchanged.
- Read MED text as UTF-8 with a Latin-1 fallback (`_med_str`), so both new and older files still read. The group-name read no longer assumes Latin-1 (`chr(byte)`).