### PR TITLE
fix(med): restore group reconstruction in read_med_multi + canonical …

### DIFF
--- a/src/meshlane/abaqus/_abaqus.py
+++ b/src/meshlane/abaqus/_abaqus.py
@@ -91,7 +91,26 @@ abaqus_to_meshio_type = {
     # 6-node quadratic
     "CPE6": "triangle6",
 }
-meshio_to_abaqus_type = {v: k for k, v in abaqus_to_meshio_type.items()}
+# Explicit write map with the canonical (plain) Abaqus type per meshio type.
+# A plain reverse of abaqus_to_meshio_type would keep the *last* key seen per
+# value, which yields non-canonical names (hexahedron -> C3D8RH, quad -> CAX4P,
+# line -> B31H). Every name below is also a key above, so writing round-trips.
+meshio_to_abaqus_type = {
+    "line": "B31",
+    "line3": "B32",
+    "triangle": "S3",
+    "triangle6": "STRI65",
+    "quad": "S4",
+    "quad8": "S8R",
+    "quad9": "S9R5",
+    "tetra": "C3D4",
+    "tetra4": "C3D4",
+    "tetra10": "C3D10",
+    "wedge": "C3D6",
+    "wedge15": "C3D15",
+    "hexahedron": "C3D8",
+    "hexahedron20": "C3D20",
+}
 
 # Read-only aliases: thermal (DC*), acoustic (AC*) and gasket (GK*) elements
 # share geometry with the displacement families. Added *after* the reverse map

--- a/src/meshlane/med/_medmulti.py
+++ b/src/meshlane/med/_medmulti.py
@@ -39,6 +39,8 @@ from ._med import (
     _reorder_med_cells,
     _write_families,
     _read_families,
+    _families_to_point_sets,
+    _families_to_cell_sets,
     _read_data,
     _parse_med_field_name,
     _write_field_step,
@@ -516,11 +518,20 @@ def _read_single_mesh(f, name):
                 field_data,
             )
 
+    # Reconstruct point_sets / cell_sets from MED families (same as the
+    # single-mesh reader) so the CLI convert path preserves groups too.
+    point_sets = _families_to_point_sets(point_tags, point_data.get("point_tags"))
+    cell_sets = _families_to_cell_sets(
+        cell_tags, cell_data.get("cell_tags"), len(cells)
+    )
+
     result = Mesh(
         points, cells,
         point_data=point_data,
         cell_data=cell_data,
         field_data=field_data,
+        point_sets=point_sets,
+        cell_sets=cell_sets,
     )
     result.point_tags = point_tags
     result.cell_tags = cell_tags

--- a/tests/test_abaqus.py
+++ b/tests/test_abaqus.py
@@ -118,6 +118,26 @@ def test_skip_non_mesh_elements(tmp_path):
     assert {c.type for c in mesh.cells} == {"tetra"}
 
 
+def test_write_canonical_element_types(tmp_path):
+    # the writer must emit the plain canonical Abaqus types, not the R/H variants
+    # a naive reverse map produces (hexahedron->C3D8RH, quad->CAX4P, line->B31H).
+    points = np.zeros((8, 3))
+    cells = [
+        ("hexahedron", np.arange(8).reshape(1, 8)),
+        ("quad", np.arange(4).reshape(1, 4)),
+        ("line", np.arange(2).reshape(1, 2)),
+    ]
+    mesh = meshlane.Mesh(points, cells)
+    f = tmp_path / "canon.inp"
+    meshlane.abaqus.write(f, mesh)
+    types = {
+        line.split("TYPE=")[1].strip()
+        for line in f.read_text().splitlines()
+        if line.startswith("*ELEMENT")
+    }
+    assert types == {"C3D8", "S4", "B31"}
+
+
 def test_unknown_type_warns_and_skips(tmp_path, capsys):
     # an unrecognized type is skipped with a warning, the rest still reads
     body = (

--- a/tests/test_med.py
+++ b/tests/test_med.py
@@ -1211,6 +1211,30 @@ def test_med_multi_write_read_two_meshes(tmp_path):
     )
 
 
+def test_med_multi_preserves_groups(tmp_path):
+    """
+    read_med_multi must reconstruct point_sets/cell_sets from MED families,
+    like the single-mesh reader. Regression: the CLI convert path uses
+    read_med_multi, and previously dropped all groups (issues #25/#29).
+    """
+    from meshlane._mesh import Mesh, CellBlock
+
+    mesh = Mesh(
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]),
+        [CellBlock("triangle", np.array([[0, 1, 2], [1, 3, 2]]))],
+        point_sets={"corner": np.array([0])},
+        cell_sets={"right": [np.array([0])], "left": [np.array([1])]},
+    )
+    filename = tmp_path / "grp.med"
+    meshlane.med.write(filename, mesh)
+
+    meshes, _ = meshlane.med.read_med_multi(filename)
+    out = meshes[0]
+
+    assert set(out.point_sets) == {"corner"}
+    assert set(out.cell_sets) == {"right", "left"}
+
+
 def test_med_multi_default_mesh_names(tmp_path):
     """
     Without explicit mesh_names, meshes must be named mesh_0, mesh_1, etc.


### PR DESCRIPTION
## Issue

Converting MED to Abaqus `.inp` with the CLI (`meshlane convert x.med y.inp`) had two bugs (issues #25, #29):

- **Groups were dropped (regression from #20, CLI path):** `meshlane convert x.med y.inp` produced only `*NODE` and `*ELEMENT`, no `*ELSET`/`*NSET`, even when the MED defined many groups. PR #20 (multi-mesh CLI) rewired the CLI to read every `.med` through `read_med_multi`, but that reader never rebuilt `point_sets`/`cell_sets` from the MED families. Before #20 the CLI used the single-mesh `read()`, which did. The Python API `meshlane.read` was never affected. 
- **Wrong element types:** Hexes wrote as `C3D8RH`, quads as `CAX4P`, lines as `B31H` (a reverse-map "last wins" artifact). Those are not valid Calculix types, so the deck would not load.

## Fix

- `read_med_multi` now reconstructs `point_sets`/`cell_sets` from MED families, reusing the single reader's existing helpers (no duplicated logic). Groups are preserved on both the CLI and API paths.
- The Abaqus writer uses an explicit canonical type map (`hexahedron`->`C3D8`, `quad`->`S4`, `line`->`B31`, ...). Every name round-trips and is valid in both Abaqus and Calculix.


- Note: writing face groups as Calculix `*SURFACE` (issue #29 point 4) is a separate feature requiring a dedicated Calculix writer, it will have a dedicated PR later on. 
